### PR TITLE
Add support for non-optional nullable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Current version: *1.0.11*
   - (Must be configured to use this mode)
   - Special handling of Option-/Optional-properties using oneOf.
 * Supports custom Class-to-format-Mapping
-    
+
 
 **Benefits**
 
-* Simple implementation - Just [one file](https://github.com/mbknor/mbknor-jackson-jsonSchema/blob/master/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala)  (for now..) 
+* Simple implementation - Just [one file](https://github.com/mbknor/mbknor-jackson-jsonSchema/blob/master/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala)  (for now..)
 * Implemented in Scala (*Built for 2.10, 2.11 and 2.12*)
 * Easy to fix and add functionality
 
@@ -36,7 +36,7 @@ Project status
 We're currently using this codebase in an ongoing (not yet released) project at work,
 and we're improving the jsonSchema-generating code when we finds issues and/or features we need that not yet is supported.
 
-I would really appreciate it if other developers wanted to start using and contributing improvements and features. 
+I would really appreciate it if other developers wanted to start using and contributing improvements and features.
 
 Dependency
 ===================
@@ -45,11 +45,11 @@ This project publishes artifacts to central maven repo.
 
 The project is also compiled using Java 8. This means that you also need to use Java 8.
 
-Artifacts for both Scala 2.10, 2.11 and 2.12 is now available (Thanks to [@bbyk](https://github.com/bbyk) for adding crossBuild functionality). 
+Artifacts for both Scala 2.10, 2.11 and 2.12 is now available (Thanks to [@bbyk](https://github.com/bbyk) for adding crossBuild functionality).
 
 Using Maven
 -----------------
- 
+
 Add this to you pom.xml:
 
     <dependency>
@@ -60,7 +60,7 @@ Add this to you pom.xml:
 
 Using sbt
 ------------
- 
+
 Add this to you sbt build-config:
 
     "com.kjetland" % "mbknor-jackson-jsonschema" %% "1.0.11"
@@ -75,17 +75,17 @@ This is how to generate jsonSchema in code using Scala:
     val objectMapper = new ObjectMapper
     val jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper)
     val jsonSchema:JsonNode = jsonSchemaGenerator.generateJsonSchema(classOf[YourPOJO])
-    
+
     val jsonSchemaAsString:String = objectMapper.writeValueAsString(jsonSchema)
 ```
 
-This is how to generate jsonSchema used for generating HTML5 GUI using [json-editor](https://github.com/jdorn/json-editor): 
+This is how to generate jsonSchema used for generating HTML5 GUI using [json-editor](https://github.com/jdorn/json-editor):
 
 ```scala
     val objectMapper = new ObjectMapper
     val jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper, config = JsonSchemaConfig.html5EnabledSchema)
     val jsonSchema:JsonNode = jsonSchemaGenerator.generateJsonSchema(classOf[YourPOJO])
-    
+
     val jsonSchemaAsString:String = objectMapper.writeValueAsString(jsonSchema)
 ```
 
@@ -98,14 +98,14 @@ This is how to generate jsonSchema using custom type-to-format-mapping using Sca
     )
     val jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper, config = config)
     val jsonSchema:JsonNode = jsonSchemaGenerator.generateJsonSchema(classOf[YourPOJO])
-    
+
     val jsonSchemaAsString:String = objectMapper.writeValueAsString(jsonSchema)
 ```
 
 **Note about Scala and Option[Int]**:
 
 Due to Java's Type Erasure it impossible to resolve the type T behind Option[T] when T is Int, Boolean, Double.
-Ass a workaround, you have to use the *@JsonDeserialize*-annotation in such cases.
+As a workaround, you have to use the *@JsonDeserialize*-annotation in such cases.
 See https://github.com/FasterXML/jackson-module-scala/wiki/FAQ#deserializing-optionint-and-other-primitive-challenges for more info.
 
 Example:
@@ -127,25 +127,52 @@ Code - Using Java
 ```java
     ObjectMapper objectMapper = new ObjectMapper();
     JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper);
-    
+
     // If using JsonSchema to generate HTML5 GUI:
     // JsonSchemaGenerator html5 = new JsonSchemaGenerator(objectMapper, JsonSchemaConfig.html5EnabledSchema() );
-    
+
     // If you want to confioure it manually:
     // JsonSchemaConfig config = JsonSchemaConfig.create(...);
     // JsonSchemaGenerator generator = new JsonSchemaGenerator(objectMapper, config);
-               
-    
+
+
     JsonNode jsonSchema = jsonSchemaGenerator.generateJsonSchema(YourPOJO.class);
-    
+
     String jsonSchemaAsString = objectMapper.writeValueAsString(jsonSchema);
+```
+
+**Nullable types**
+
+Out of the box, the generator does not support nullable types. There is a preconfigured `JsonSchemaGenerator` configuration shortcut that can be used to enable them:
+
+```java
+JsonSchemaConfig config = JsonSchemaConfig.nullableJsonSchemaDraft4();
+JsonSchemaGenerator generator = new JsonSchemaGenerator(objectMapper, config);
+```
+
+Under the hood `nullableJsonSchemaDraft4` toggles the `useOneOfForOption` and `useOneOfForNullables` properties on `JsonSchemaConfig`.
+
+When support is enabled, the following types may be made nullable:
+ - Use `Optional<T>` (or Scala's `Option`)
+ - Use a non-optional, non-primitive type (IE: `String`, `Boolean`, `Integer` etc) 
+
+If you've otherwise enabled support for nullable types, but need to suppress this at a per-property level, you can do this like so:
+
+```java
+// A standard validation @NotNull annotation.
+@NotNull
+public String foo;
+
+// Using the Jackson @JsonProperty annotation, specifying the attribute as required.
+@JsonProperty(required = true)
+public String bar;
 ```
 
 Backstory
 --------------
 
 
-At work we've been using the original [jackson-module-jsonSchema](https://github.com/FasterXML/jackson-module-jsonSchema) 
+At work we've been using the original [jackson-module-jsonSchema](https://github.com/FasterXML/jackson-module-jsonSchema)
 to generate schemas used when rendering dynamic GUI using [https://github.com/jdorn/json-editor](https://github.com/jdorn/json-editor).
 
 Recently we needed to support POJO's using polymorphism like this:
@@ -159,12 +186,12 @@ Recently we needed to support POJO's using polymorphism like this:
             @JsonSubTypes.Type(value = Child1.class, name = "child1"),
             @JsonSubTypes.Type(value = Child2.class, name = "child2") })
     public abstract class Parent {
-    
+
         public String parentString;
-        
+
     }
 ```
-    
+
 This is not supported by the original [jackson-module-jsonSchema](https://github.com/FasterXML/jackson-module-jsonSchema).
 I have spent many hours trying to figure out how to modify/improve it without any luck,
 and since it is implemented in such a complicated way, I decided to instead write my own

--- a/src/test/java/com/kjetland/jackson/jsonSchema/UseItFromJavaTest.java
+++ b/src/test/java/com/kjetland/jackson/jsonSchema/UseItFromJavaTest.java
@@ -1,8 +1,6 @@
 package com.kjetland.jackson.jsonSchema;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import scala.None;
-import scala.Option;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -27,7 +25,7 @@ public class UseItFromJavaTest {
         Map<String,String> customMapping = new HashMap<>();
         customMapping.put(OffsetDateTime.class.getName(), "date-time");
         JsonSchemaConfig config = JsonSchemaConfig.create(
-                true, Optional.of("A"), true, true, true, true, true, true, customMapping);
+                true, Optional.of("A"), true, true, true, true, true, true, true, customMapping);
         JsonSchemaGenerator g2 = new JsonSchemaGenerator(objectMapper, config);
     }
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/CreateJsonSchemaGeneratorFromJava.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/CreateJsonSchemaGeneratorFromJava.java
@@ -3,10 +3,9 @@ package com.kjetland.jackson.jsonSchema;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class CreateJsonSchemaGeneratorFromJava {
-
     public CreateJsonSchemaGeneratorFromJava(ObjectMapper objectMapper) {
         JsonSchemaGenerator vanilla = new JsonSchemaGenerator(objectMapper);
-        JsonSchemaGenerator html5 = new JsonSchemaGenerator(objectMapper, JsonSchemaConfig.html5EnabledSchema() );
-
+        JsonSchemaGenerator html5 = new JsonSchemaGenerator(objectMapper, JsonSchemaConfig.html5EnabledSchema());
+        JsonSchemaGenerator nullable = new JsonSchemaGenerator(objectMapper, JsonSchemaConfig.nullableJsonSchemaDraft4());
     }
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -3,19 +3,15 @@ package com.kjetland.jackson.jsonSchema
 import java.time.{LocalDate, LocalDateTime, OffsetDateTime}
 import java.util
 import java.util.{Optional, TimeZone}
-import javax.validation.constraints._
 
-import com.fasterxml.jackson.annotation.{JsonProperty, JsonSubTypes, JsonTypeInfo, JsonValue}
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.databind.node.{ArrayNode, MissingNode, NullNode, ObjectNode}
+import com.fasterxml.jackson.databind.node.{ArrayNode, MissingNode, ObjectNode}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.joda.JodaModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.github.fge.jsonschema.main.JsonSchemaFactory
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault
 import com.kjetland.jackson.jsonSchema.testData._
 import com.kjetland.jackson.jsonSchema.testData.mixin.{MixinChild1, MixinModule, MixinParent}
 import com.kjetland.jackson.jsonSchema.testDataScala._
@@ -40,11 +36,11 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       om.registerModule(simpleModule)
 
       om.registerModule(new JavaTimeModule)
-      om.registerModule(new Jdk8Module )
+      om.registerModule(new Jdk8Module)
       om.registerModule(new JodaModule)
 
       // For the mixin-test
-      om.registerModule( mixinModule)
+      om.registerModule(mixinModule)
 
       om.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
       om.setTimeZone(TimeZone.getDefault())
@@ -60,6 +56,12 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
   val vanillaJsonSchemaDraft4WithIds = JsonSchemaConfig.html5EnabledSchema.copy(useTypeIdForDefinitionName = true)
   val jsonSchemaGeneratorWithIds = new JsonSchemaGenerator(_objectMapperScala, debug = true, vanillaJsonSchemaDraft4WithIds)
 
+  val jsonSchemaGeneratorNullable = new JsonSchemaGenerator(_objectMapper, debug = true, config = JsonSchemaConfig.nullableJsonSchemaDraft4)
+  val jsonSchemaGeneratorHTML5Nullable = new JsonSchemaGenerator(_objectMapper, debug = true,
+                                                                 config = JsonSchemaConfig.html5EnabledSchema.copy(useOneOfForNullables = true))
+  val jsonSchemaGeneratorWithIdsNullable = new JsonSchemaGenerator(_objectMapperScala, debug = true,
+                                                                   vanillaJsonSchemaDraft4WithIds.copy(useOneOfForNullables = true))
+
   val testData = new TestData{}
 
   def asPrettyJson(node:JsonNode, om:ObjectMapper):String = {
@@ -73,13 +75,13 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
   }
 
   // Asserts that we're able to go from object => json => equal object
-  // deserType might be a class which o extends (polymorphism)
-  def assertToFromJson(g:JsonSchemaGenerator, o:Any, deserType:Class[_]): JsonNode = {
+  // desiredType might be a class which o extends (polymorphism)
+  def assertToFromJson(g:JsonSchemaGenerator, o:Any, desiredType:Class[_]): JsonNode = {
     val json = g.rootObjectMapper.writeValueAsString(o)
     println(s"json: $json")
     val jsonNode = g.rootObjectMapper.readTree(json)
-    val r = g.rootObjectMapper.treeToValue(jsonNode, deserType)
-    assert( o == r)
+    val r = g.rootObjectMapper.treeToValue(jsonNode, desiredType)
+    assert(o == r)
     jsonNode
   }
 
@@ -88,7 +90,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     jsonToTestAgainstSchema.foreach {
       node =>
         val r = schemaValidator.validate(node)
-        if ( !r.isSuccess ) {
+        if (!r.isSuccess) {
           throw new Exception("json does not validate against schema: " + r)
         }
 
@@ -103,7 +105,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     println("--------------------------------------------")
     println(asPrettyJson(schema, g.rootObjectMapper))
 
-    assert( JsonSchemaGenerator.JSON_SCHEMA_DRAFT_4_URL == schema.at("/$schema").asText())
+    assert(JsonSchemaGenerator.JSON_SCHEMA_DRAFT_4_URL == schema.at("/$schema").asText())
 
     useSchema(schema, jsonToTestAgainstSchema)
 
@@ -122,16 +124,15 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       "title" : "child1",
       "required" : [ "type" ]
     */
-    assert( node.at(s"/properties/$typeParamName/type").asText() == "string" )
-    assert( node.at(s"/properties/$typeParamName/enum/0").asText() == typeName)
-    assert( node.at(s"/properties/$typeParamName/default").asText() == typeName)
-    assert( node.at(s"/title").asText() == typeName)
-    assert( getRequiredList(node).contains(typeParamName))
+    assert(node.at(s"/properties/$typeParamName/type").asText() == "string")
+    assert(node.at(s"/properties/$typeParamName/enum/0").asText() == typeName)
+    assert(node.at(s"/properties/$typeParamName/default").asText() == typeName)
+    assert(node.at(s"/title").asText() == typeName)
+    assert(getRequiredList(node).contains(typeParamName))
 
     if (html5Checks) {
-      assert( node.at(s"/properties/$typeParamName/options/hidden").asBoolean() == true )
+      assert(node.at(s"/properties/$typeParamName/options/hidden").asBoolean())
     }
-
   }
 
   def getArrayNodeAsListOfStrings(node:JsonNode):List[String] = {
@@ -148,7 +149,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
   def getNodeViaArrayOfRefs(root:JsonNode, pathToArrayOfRefs:String, definitionName:String):JsonNode = {
     val nodeWhereArrayOfRefsIs:ArrayNode = root.at(pathToArrayOfRefs).asInstanceOf[ArrayNode]
     val arrayItemNodes = nodeWhereArrayOfRefsIs.iterator().asScala.toList
-    val ref = arrayItemNodes.map(_.get("$ref").asText()).find( _.endsWith(s"/$definitionName")).get
+    val ref = arrayItemNodes.map(_.get("$ref").asText()).find(_.endsWith(s"/$definitionName")).get
     // use ref to look the node up
     val fixedRef = ref.substring(1) // Removing starting #
     root.at(fixedRef)
@@ -156,7 +157,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
 
   def getNodeViaRefs(root:JsonNode, nodeWithRef:JsonNode, definitionName:String):ObjectNode = {
     val ref = nodeWithRef.at("/$ref").asText()
-    assert( ref.endsWith(s"/$definitionName"))
+    assert(ref.endsWith(s"/$definitionName"))
     // use ref to look the node up
     val fixedRef = ref.substring(1) // Removing starting #
     root.at(fixedRef).asInstanceOf[ObjectNode]
@@ -167,30 +168,38 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     val enumList = MyEnum.values().toList.map(_.toString)
 
     {
-
       val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.classNotExtendingAnything)
       val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.classNotExtendingAnything.getClass, Some(jsonNode))
 
-      assert( false == schema.at("/additionalProperties").asBoolean())
-      assert( schema.at("/properties/someString/type").asText() == "string")
+      assert(!schema.at("/additionalProperties").asBoolean())
+      assert(schema.at("/properties/someString/type").asText() == "string")
 
-      assert( schema.at("/properties/myEnum/type").asText() == "string")
-      assert( getArrayNodeAsListOfStrings(schema.at("/properties/myEnum/enum")) == enumList)
+      assert(schema.at("/properties/myEnum/type").asText() == "string")
+      assert(getArrayNodeAsListOfStrings(schema.at("/properties/myEnum/enum")) == enumList)
     }
 
     {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.classNotExtendingAnything)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.classNotExtendingAnything.getClass, Some(jsonNode))
 
+      assert(!schema.at("/additionalProperties").asBoolean())
+      assertNullableType(schema, "/properties/someString", "string")
+
+      assertNullableType(schema, "/properties/myEnum", "string")
+      assert(getArrayNodeAsListOfStrings(schema.at("/properties/myEnum/oneOf/1/enum")) == enumList)
+    }
+
+    {
       val jsonNode = assertToFromJson(jsonSchemaGeneratorScala, testData.classNotExtendingAnythingScala)
       val schema = generateAndValidateSchema(jsonSchemaGeneratorScala, testData.classNotExtendingAnythingScala.getClass, Some(jsonNode))
 
-      assert( false == schema.at("/additionalProperties").asBoolean())
-      assert( schema.at("/properties/someString/type").asText() == "string")
+      assert(!schema.at("/additionalProperties").asBoolean())
+      assert(schema.at("/properties/someString/type").asText() == "string")
 
-      assert( schema.at("/properties/myEnum/type").asText() == "string")
-      assert( getArrayNodeAsListOfStrings(schema.at("/properties/myEnum/enum")) == enumList)
-      assert( getArrayNodeAsListOfStrings(schema.at("/properties/myEnumO/enum")) == enumList)
+      assert(schema.at("/properties/myEnum/type").asText() == "string")
+      assert(getArrayNodeAsListOfStrings(schema.at("/properties/myEnum/enum")) == enumList)
+      assert(getArrayNodeAsListOfStrings(schema.at("/properties/myEnumO/enum")) == enumList)
     }
-
   }
 
   test("Generating schema for concrete class which happens to extend class using @JsonTypeInfo") {
@@ -199,8 +208,8 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       val jsonNode = assertToFromJson(g, pojo)
       val schema = generateAndValidateSchema(g, clazz, Some(jsonNode))
 
-      assert( false == schema.at("/additionalProperties").asBoolean())
-      assert( schema.at("/properties/parentString/type").asText() == "string")
+      assert(!schema.at("/additionalProperties").asBoolean())
+      assert(schema.at("/properties/parentString/type").asText() == "string")
       assertJsonSubTypesInfo(schema, "type", "child1")
     }
 
@@ -211,12 +220,24 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
   test("Generate schema for regular class which has a property of class annotated with @JsonTypeInfo") {
 
     def assertDefaultValues(schema:JsonNode): Unit ={
-      assert( schema.at("/properties/stringWithDefault/type").asText() == "string" )
-      assert( schema.at("/properties/stringWithDefault/default").asText() == "x" )
-      assert( schema.at("/properties/intWithDefault/type").asText() == "integer" )
-      assert( schema.at("/properties/intWithDefault/default").asInt() == 12 )
-      assert( schema.at("/properties/booleanWithDefault/type").asText() == "boolean" )
-      assert( schema.at("/properties/booleanWithDefault/default").asBoolean() == true )
+      assert(schema.at("/properties/stringWithDefault/type").asText() == "string")
+      assert(schema.at("/properties/stringWithDefault/default").asText() == "x")
+      assert(schema.at("/properties/intWithDefault/type").asText() == "integer")
+      assert(schema.at("/properties/intWithDefault/default").asInt() == 12)
+      assert(schema.at("/properties/booleanWithDefault/type").asText() == "boolean")
+      assert(schema.at("/properties/booleanWithDefault/default").asBoolean())
+    }
+
+    def assertNullableDefaultValues(schema:JsonNode): Unit = {
+      assert(schema.at("/properties/stringWithDefault/oneOf/0/type").asText() == "null")
+      assert(schema.at("/properties/stringWithDefault/oneOf/0/title").asText() == "Not included")
+      assert(schema.at("/properties/stringWithDefault/oneOf/1/type").asText() == "string")
+      assert(schema.at("/properties/stringWithDefault/oneOf/1/default").asText() == "x")
+
+      assert(schema.at("/properties/intWithDefault/type").asText() == "integer")
+      assert(schema.at("/properties/intWithDefault/default").asInt() == 12)
+      assert(schema.at("/properties/booleanWithDefault/type").asText() == "boolean")
+      assert(schema.at("/properties/booleanWithDefault/default").asBoolean())
     }
 
     // Java
@@ -224,14 +245,12 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.pojoWithParent)
       val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.pojoWithParent.getClass, Some(jsonNode))
 
-      assert(false == schema.at("/additionalProperties").asBoolean())
+      assert(!schema.at("/additionalProperties").asBoolean())
       assert(schema.at("/properties/pojoValue/type").asText() == "boolean")
       assertDefaultValues(schema)
 
-
       assertChild1(schema, "/properties/child/oneOf")
       assertChild2(schema, "/properties/child/oneOf")
-
     }
 
     // Java - html5
@@ -239,28 +258,51 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       val jsonNode = assertToFromJson(jsonSchemaGeneratorHTML5, testData.pojoWithParent)
       val schema = generateAndValidateSchema(jsonSchemaGeneratorHTML5, testData.pojoWithParent.getClass, Some(jsonNode))
 
-      assert(false == schema.at("/additionalProperties").asBoolean())
+      assert(!schema.at("/additionalProperties").asBoolean())
       assert(schema.at("/properties/pojoValue/type").asText() == "boolean")
       assertDefaultValues(schema)
 
       assertChild1(schema, "/properties/child/oneOf", html5Checks = true)
       assertChild2(schema, "/properties/child/oneOf", html5Checks = true)
+    }
 
+    // Java - html5/nullable
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorHTML5Nullable, testData.pojoWithParent)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorHTML5Nullable, testData.pojoWithParent.getClass, Some(jsonNode))
+
+      assert(!schema.at("/additionalProperties").asBoolean())
+      assertNullableType(schema, "/properties/pojoValue", "boolean")
+      assertNullableDefaultValues(schema)
+
+      assertNullableChild1(schema, "/properties/child/oneOf/1/oneOf", html5Checks = true)
+      assertNullableChild2(schema, "/properties/child/oneOf/1/oneOf", html5Checks = true)
     }
 
     //Using fully-qualified class names
     {
-
       val jsonNode = assertToFromJson(jsonSchemaGeneratorWithIds, testData.pojoWithParent)
       val schema = generateAndValidateSchema(jsonSchemaGeneratorWithIds, testData.pojoWithParent.getClass, Some(jsonNode))
 
-      assert(false == schema.at("/additionalProperties").asBoolean())
+      assert(!schema.at("/additionalProperties").asBoolean())
       assert(schema.at("/properties/pojoValue/type").asText() == "boolean")
       assertDefaultValues(schema)
 
-      assertChild1(schema, "/properties/child/oneOf", "com.kjetland.jackson.jsonSchema.testData.Child1", false)
-      assertChild2(schema, "/properties/child/oneOf", "com.kjetland.jackson.jsonSchema.testData.Child2", false)
-      
+      assertChild1(schema, "/properties/child/oneOf", "com.kjetland.jackson.jsonSchema.testData.Child1")
+      assertChild2(schema, "/properties/child/oneOf", "com.kjetland.jackson.jsonSchema.testData.Child2")
+    }
+
+    // Using fully-qualified class names and nullable types
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorWithIdsNullable, testData.pojoWithParent)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorWithIdsNullable, testData.pojoWithParent.getClass, Some(jsonNode))
+
+      assert(!schema.at("/additionalProperties").asBoolean())
+      assertNullableType(schema, "/properties/pojoValue", "boolean")
+      assertNullableDefaultValues(schema)
+
+      assertNullableChild1(schema, "/properties/child/oneOf/1/oneOf", "com.kjetland.jackson.jsonSchema.testData.Child1")
+      assertNullableChild2(schema, "/properties/child/oneOf/1/oneOf", "com.kjetland.jackson.jsonSchema.testData.Child2")
     }
     
     // Scala
@@ -268,32 +310,58 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       val jsonNode = assertToFromJson(jsonSchemaGeneratorScala, testData.pojoWithParentScala)
       val schema = generateAndValidateSchema(jsonSchemaGeneratorScala, testData.pojoWithParentScala.getClass, Some(jsonNode))
 
-      assert(false == schema.at("/additionalProperties").asBoolean())
+      assert(!schema.at("/additionalProperties").asBoolean())
       assert(schema.at("/properties/pojoValue/type").asText() == "boolean")
       assertDefaultValues(schema)
 
       assertChild1(schema, "/properties/child/oneOf", "Child1Scala")
       assertChild2(schema, "/properties/child/oneOf", "Child2Scala")
-
     }
-
   }
 
   def assertChild1(node:JsonNode, path:String, defName:String = "Child1", html5Checks:Boolean = false): Unit ={
     val child1 = getNodeViaArrayOfRefs(node, path, defName)
     assertJsonSubTypesInfo(child1, "type", "child1", html5Checks)
-    assert( child1.at("/properties/parentString/type").asText() == "string" )
-    assert( child1.at("/properties/child1String/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String2/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String3/type").asText() == "string" )
+    assert(child1.at("/properties/parentString/type").asText() == "string")
+    assert(child1.at("/properties/child1String/type").asText() == "string")
+    assert(child1.at("/properties/_child1String2/type").asText() == "string")
+    assert(child1.at("/properties/_child1String3/type").asText() == "string")
+    assert(getRequiredList(child1).contains("_child1String3"))
+  }
+
+  def assertNullableChild1(node:JsonNode, path:String, defName:String = "Child1", html5Checks:Boolean = false): Unit ={
+    val child1 = getNodeViaArrayOfRefs(node, path, defName)
+    assertJsonSubTypesInfo(child1, "type", "child1", html5Checks)
+    assertNullableType(child1, "/properties/parentString", "string")
+    assertNullableType(child1, "/properties/child1String", "string")
+    assertNullableType(child1, "/properties/_child1String2", "string")
+    assert(child1.at("/properties/_child1String3/type").asText() == "string")
     assert(getRequiredList(child1).contains("_child1String3"))
   }
 
   def assertChild2(node:JsonNode, path:String, defName:String = "Child2", html5Checks:Boolean = false): Unit ={
     val child2 = getNodeViaArrayOfRefs(node, path, defName)
     assertJsonSubTypesInfo(child2, "type", "child2", html5Checks)
-    assert( child2.at("/properties/parentString/type").asText() == "string" )
-    assert( child2.at("/properties/child2int/type").asText() == "integer" )
+    assert(child2.at("/properties/parentString/type").asText() == "string")
+    assert(child2.at("/properties/child2int/type").asText() == "integer")
+  }
+
+  def assertNullableChild2(node:JsonNode, path:String, defName:String = "Child2", html5Checks:Boolean = false): Unit = {
+    val child2 = getNodeViaArrayOfRefs(node, path, defName)
+    assertJsonSubTypesInfo(child2, "type", "child2", html5Checks)
+    assertNullableType(child2, "/properties/parentString", "string")
+    assertNullableType(child2, "/properties/child2int", "integer")
+  }
+
+  def assertNullableType(node:JsonNode, path:String, expectedType:String): Unit = {
+    val nullType = node.at(path).at("/oneOf/0")
+    assert(nullType.at("/type").asText() == "null")
+    assert(nullType.at("/title").asText() == "Not included")
+
+    val valueType = node.at(path).at("/oneOf/1")
+    assert(valueType.at("/type").asText() == expectedType)
+
+    Option(getRequiredList(node)).map(xs => assert(!xs.contains(path.split('/').last)))
   }
 
   test("Generate schema for super class annotated with @JsonTypeInfo") {
@@ -302,6 +370,17 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     {
       val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.child1)
       assertToFromJson(jsonSchemaGenerator, testData.child1, classOf[Parent])
+
+      val schema = generateAndValidateSchema(jsonSchemaGenerator, classOf[Parent], Some(jsonNode))
+
+      assertChild1(schema, "/oneOf")
+      assertChild2(schema, "/oneOf")
+    }
+
+    // Java + Nullables
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.child1)
+      assertToFromJson(jsonSchemaGeneratorNullable, testData.child1, classOf[Parent])
 
       val schema = generateAndValidateSchema(jsonSchemaGenerator, classOf[Parent], Some(jsonNode))
 
@@ -324,7 +403,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
 
   test("primitives") {
 
-    // java
+    // Java
     {
       val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.manyPrimitives)
       val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.manyPrimitives.getClass, Some(jsonNode))
@@ -356,7 +435,35 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       assert(getArrayNodeAsListOfStrings(schema.at("/properties/myEnum/enum")) == MyEnum.values().toList.map(_.toString))
     }
 
-    // scala
+    // Java with nullable types
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.manyPrimitivesNulls)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.manyPrimitivesNulls.getClass, Some(jsonNode))
+
+      assertNullableType(schema, "/properties/_string", "string")
+      assertNullableType(schema, "/properties/_integer", "integer")
+      assertNullableType(schema, "/properties/_booleanObject", "boolean")
+      assertNullableType(schema, "/properties/_doubleObject", "number")
+
+      // We're actually going to test this elsewhere, because if we set this to null here it'll break the "generateAndValidateSchema"
+      // test. What's fun is that the type system will allow you to set the value as null, but the schema won't (because there's a @NotNull) annotation on it.
+      assert(schema.at("/properties/_booleanObjectWithNotNull/type").asText() == "boolean")
+      assert(getRequiredList(schema).contains("_booleanObjectWithNotNull"))
+
+      assert(schema.at("/properties/_int/type").asText() == "integer")
+      assert(getRequiredList(schema).contains("_int"))
+
+      assert(schema.at("/properties/_booleanPrimitive/type").asText() == "boolean")
+      assert(getRequiredList(schema).contains("_booleanPrimitive"))
+
+      assert(schema.at("/properties/_doublePrimitive/type").asText() == "number")
+      assert(getRequiredList(schema).contains("_doublePrimitive"))
+
+      assertNullableType(schema, "/properties/myEnum", "string")
+      assert(getArrayNodeAsListOfStrings(schema.at("/properties/myEnum/oneOf/1/enum")) == MyEnum.values().toList.map(_.toString))
+    }
+
+    // Scala
     {
       val jsonNode = assertToFromJson(jsonSchemaGeneratorScala, testData.manyPrimitivesScala)
       val schema = generateAndValidateSchema(jsonSchemaGeneratorScala, testData.manyPrimitivesScala.getClass, Some(jsonNode))
@@ -393,14 +500,13 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     val child1 = getNodeViaRefs(schema, schema.at("/properties/child1"), "Child1Scala")
 
     assertJsonSubTypesInfo(child1, "type", "child1")
-    assert( child1.at("/properties/parentString/type").asText() == "string" )
-    assert( child1.at("/properties/child1String/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String2/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String3/type").asText() == "string" )
+    assert(child1.at("/properties/parentString/type").asText() == "string")
+    assert(child1.at("/properties/child1String/type").asText() == "string")
+    assert(child1.at("/properties/_child1String2/type").asText() == "string")
+    assert(child1.at("/properties/_child1String3/type").asText() == "string")
 
     assert(schema.at("/properties/optionalList/type").asText() == "array")
     assert(schema.at("/properties/optionalList/items/$ref").asText() == "#/definitions/ClassNotExtendingAnythingScala")
-
   }
 
   test("java using option") {
@@ -416,31 +522,46 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     val child1 = getNodeViaRefs(schema, schema.at("/properties/child1"), "Child1")
 
     assertJsonSubTypesInfo(child1, "type", "child1")
-    assert( child1.at("/properties/parentString/type").asText() == "string" )
-    assert( child1.at("/properties/child1String/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String2/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String3/type").asText() == "string" )
+    assert(child1.at("/properties/parentString/type").asText() == "string")
+    assert(child1.at("/properties/child1String/type").asText() == "string")
+    assert(child1.at("/properties/_child1String2/type").asText() == "string")
+    assert(child1.at("/properties/_child1String3/type").asText() == "string")
 
     assert(schema.at("/properties/optionalList/type").asText() == "array")
     assert(schema.at("/properties/optionalList/items/$ref").asText() == "#/definitions/ClassNotExtendingAnything")
+  }
 
+  test("nullable Java using option") {
+    val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.pojoUsingOptionalJava)
+    val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.pojoUsingOptionalJava.getClass, Some(jsonNode))
+
+    assertNullableType(schema, "/properties/_string", "string")
+    assertNullableType(schema, "/properties/_integer", "integer")
+
+    val child1 = getNodeViaRefs(schema, schema.at("/properties/child1/oneOf/1"), "Child1")
+
+    assertJsonSubTypesInfo(child1, "type", "child1")
+    assertNullableType(child1, "/properties/parentString", "string")
+    assertNullableType(child1, "/properties/child1String", "string")
+    assertNullableType(child1, "/properties/_child1String2", "string")
+    assert(child1.at("/properties/_child1String3/type").asText() == "string")
+
+    assertNullableType(schema, "/properties/optionalList", "array")
+    assert(schema.at("/properties/optionalList/oneOf/1/items/$ref").asText() == "#/definitions/ClassNotExtendingAnything")
   }
 
   test("custom serializer not overriding JsonSerializer.acceptJsonFormatVisitor") {
-
     val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.pojoWithCustomSerializer)
     val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.pojoWithCustomSerializer.getClass, Some(jsonNode))
-    assert( schema.asInstanceOf[ObjectNode].fieldNames().asScala.toList == List("$schema", "title")) // Emptyt schema due to custom serializer
+    assert(schema.asInstanceOf[ObjectNode].fieldNames().asScala.toList == List("$schema", "title")) // Empty schema due to custom serializer
   }
 
   test("object with property using custom serializer not overriding JsonSerializer.acceptJsonFormatVisitor") {
-
     val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.objectWithPropertyWithCustomSerializer)
     val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.objectWithPropertyWithCustomSerializer.getClass, Some(jsonNode))
-    assert( schema.at("/properties/s/type").asText() == "string")
-    assert( schema.at("/properties/child").asInstanceOf[ObjectNode].fieldNames().asScala.toList == List())
+    assert(schema.at("/properties/s/type").asText() == "string")
+    assert(schema.at("/properties/child").asInstanceOf[ObjectNode].fieldNames().asScala.toList == List())
   }
-
 
   test("pojoWithArrays") {
 
@@ -471,102 +592,153 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       assert(schema.at("/properties/listOfListOfStrings/items/items/type").asText() == "string")
     }
 
-    doTest( testData.pojoWithArrays, testData.pojoWithArrays.getClass, jsonSchemaGenerator)
-    doTest( testData.pojoWithArraysScala, testData.pojoWithArraysScala.getClass, jsonSchemaGeneratorScala)
+    doTest(testData.pojoWithArrays, testData.pojoWithArrays.getClass, jsonSchemaGenerator)
+    doTest(testData.pojoWithArraysScala, testData.pojoWithArraysScala.getClass, jsonSchemaGeneratorScala)
+  }
 
+  test("pojoWithArraysNullable") {
+    val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.pojoWithArrays)
+    val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.pojoWithArrays.getClass, Some(jsonNode))
+
+    assertNullableType(schema, "/properties/intArray1", "array")
+    assert(schema.at("/properties/intArray1/oneOf/1/items/type").asText() == "integer")
+
+    assertNullableType(schema, "/properties/stringArray", "array")
+    assert(schema.at("/properties/stringArray/oneOf/1/items/type").asText() == "string")
+
+    assertNullableType(schema, "/properties/stringList", "array")
+    assert(schema.at("/properties/stringList/oneOf/1/items/type").asText() == "string")
+
+    assertNullableType(schema, "/properties/polymorphismList", "array")
+    assertNullableChild1(schema, "/properties/polymorphismList/oneOf/1/items/oneOf")
+    assertNullableChild2(schema, "/properties/polymorphismList/oneOf/1/items/oneOf")
+
+    assertNullableType(schema, "/properties/polymorphismArray", "array")
+    assertNullableChild1(schema, "/properties/polymorphismArray/oneOf/1/items/oneOf")
+    assertNullableChild2(schema, "/properties/polymorphismArray/oneOf/1/items/oneOf")
+
+    assertNullableType(schema, "/properties/listOfListOfStrings", "array")
+    assert(schema.at("/properties/listOfListOfStrings/oneOf/1/items/type").asText() == "array")
+    assert(schema.at("/properties/listOfListOfStrings/oneOf/1/items/items/type").asText() == "string")
   }
 
   test("recursivePojo") {
-    val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.recursivePojo)
-    val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.recursivePojo.getClass, Some(jsonNode))
+    // Non-nullable Java types
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.recursivePojo)
+      val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.recursivePojo.getClass, Some(jsonNode))
 
-    assert( schema.at("/properties/myText/type").asText() == "string")
+      assert(schema.at("/properties/myText/type").asText() == "string")
 
-    assert( schema.at("/properties/children/type").asText() == "array")
-    val defViaRef = getNodeViaRefs(schema, schema.at("/properties/children/items"), "RecursivePojo")
+      assert(schema.at("/properties/children/type").asText() == "array")
+      val defViaRef = getNodeViaRefs(schema, schema.at("/properties/children/items"), "RecursivePojo")
 
-    assert( defViaRef.at("/properties/myText/type").asText() == "string")
-    assert( defViaRef.at("/properties/children/type").asText() == "array")
-    val defViaRef2 = getNodeViaRefs(schema, defViaRef.at("/properties/children/items"), "RecursivePojo")
+      assert(defViaRef.at("/properties/myText/type").asText() == "string")
+      assert(defViaRef.at("/properties/children/type").asText() == "array")
+      val defViaRef2 = getNodeViaRefs(schema, defViaRef.at("/properties/children/items"), "RecursivePojo")
 
-    assert( defViaRef == defViaRef2)
+      assert(defViaRef == defViaRef2)
+    }
 
+    // Nullable Java types
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.recursivePojo)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.recursivePojo.getClass, Some(jsonNode))
+
+      assertNullableType(schema, "/properties/myText", "string")
+
+      assertNullableType(schema, "/properties/children", "array")
+      val defViaRef = getNodeViaRefs(schema, schema.at("/properties/children/oneOf/1/items"), "RecursivePojo")
+
+      assertNullableType(defViaRef, "/properties/myText", "string")
+      assertNullableType(defViaRef, "/properties/children", "array")
+      val defViaRef2 = getNodeViaRefs(schema, defViaRef.at("/properties/children/oneOf/1/items"), "RecursivePojo")
+
+      assert(defViaRef == defViaRef2)
+    }
   }
 
   test("pojo using Maps") {
-    val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.pojoUsingMaps)
-    val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.pojoUsingMaps.getClass, Some(jsonNode))
+    // Use our standard Java validator
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.pojoUsingMaps)
+      val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.pojoUsingMaps.getClass, Some(jsonNode))
 
-    assert( schema.at("/properties/string2Integer/type").asText() == "object")
-    assert( schema.at("/properties/string2Integer/additionalProperties/type").asText() == "integer")
+      assert(schema.at("/properties/string2Integer/type").asText() == "object")
+      assert(schema.at("/properties/string2Integer/additionalProperties/type").asText() == "integer")
 
-    assert( schema.at("/properties/string2String/type").asText() == "object")
-    assert( schema.at("/properties/string2String/additionalProperties/type").asText() == "string")
+      assert(schema.at("/properties/string2String/type").asText() == "object")
+      assert(schema.at("/properties/string2String/additionalProperties/type").asText() == "string")
 
-    assert( schema.at("/properties/string2PojoUsingJsonTypeInfo/type").asText() == "object")
-    assert( schema.at("/properties/string2PojoUsingJsonTypeInfo/additionalProperties/oneOf/0/$ref").asText() == "#/definitions/Child1")
-    assert( schema.at("/properties/string2PojoUsingJsonTypeInfo/additionalProperties/oneOf/1/$ref").asText() == "#/definitions/Child2")
+      assert(schema.at("/properties/string2PojoUsingJsonTypeInfo/type").asText() == "object")
+      assert(schema.at("/properties/string2PojoUsingJsonTypeInfo/additionalProperties/oneOf/0/$ref").asText() == "#/definitions/Child1")
+      assert(schema.at("/properties/string2PojoUsingJsonTypeInfo/additionalProperties/oneOf/1/$ref").asText() == "#/definitions/Child2")
+    }
+
+    // Try it with nullable types.
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.pojoUsingMaps)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.pojoUsingMaps.getClass, Some(jsonNode))
+
+      assertNullableType(schema, "/properties/string2Integer", "object")
+      assert(schema.at("/properties/string2Integer/oneOf/1/additionalProperties/type").asText() == "integer")
+
+      assertNullableType(schema, "/properties/string2String", "object")
+      assert(schema.at("/properties/string2String/oneOf/1/additionalProperties/type").asText() == "string")
+
+      assertNullableType(schema, "/properties/string2PojoUsingJsonTypeInfo", "object")
+      assert(schema.at("/properties/string2PojoUsingJsonTypeInfo/oneOf/1/additionalProperties/oneOf/0/$ref").asText() == "#/definitions/Child1")
+      assert(schema.at("/properties/string2PojoUsingJsonTypeInfo/oneOf/1/additionalProperties/oneOf/1/$ref").asText() == "#/definitions/Child2")
+    }
   }
 
   test("pojo Using Custom Annotations") {
     val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.pojoUsingFormat)
     val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.pojoUsingFormat.getClass, Some(jsonNode))
     val schemaHTML5Date = generateAndValidateSchema(jsonSchemaGeneratorHTML5, testData.pojoUsingFormat.getClass, Some(jsonNode))
+    val schemaHTML5DateNullable = generateAndValidateSchema(jsonSchemaGeneratorHTML5Nullable, testData.pojoUsingFormat.getClass, Some(jsonNode))
 
-    assert( schema.at("/format").asText() == "grid")
-    assert( schema.at("/description").asText() == "This is our pojo")
-    assert( schema.at("/title").asText() == "Pojo using format")
-
-
-    assert( schema.at("/properties/emailValue/type").asText() == "string")
-    assert( schema.at("/properties/emailValue/format").asText() == "email")
-    assert( schema.at("/properties/emailValue/description").asText() == "This is our email value")
-    assert( schema.at("/properties/emailValue/title").asText() == "Email value")
-
-    assert( schema.at("/properties/choice/type").asText() == "boolean")
-    assert( schema.at("/properties/choice/format").asText() == "checkbox")
-
-    assert( schema.at("/properties/dateTime/type").asText() == "string")
-    assert( schema.at("/properties/dateTime/format").asText() == "date-time")
-    assert( schema.at("/properties/dateTime/description").asText() == "This is description from @JsonPropertyDescription")
-    assert( schemaHTML5Date.at("/properties/dateTime/format").asText() == "datetime")
+    assert(schema.at("/format").asText() == "grid")
+    assert(schema.at("/description").asText() == "This is our pojo")
+    assert(schema.at("/title").asText() == "Pojo using format")
 
 
-    assert( schema.at("/properties/dateTimeWithAnnotation/type").asText() == "string")
-    assert( schema.at("/properties/dateTimeWithAnnotation/format").asText() == "text")
+    assert(schema.at("/properties/emailValue/type").asText() == "string")
+    assert(schema.at("/properties/emailValue/format").asText() == "email")
+    assert(schema.at("/properties/emailValue/description").asText() == "This is our email value")
+    assert(schema.at("/properties/emailValue/title").asText() == "Email value")
+
+    assert(schema.at("/properties/choice/type").asText() == "boolean")
+    assert(schema.at("/properties/choice/format").asText() == "checkbox")
+
+    assert(schema.at("/properties/dateTime/type").asText() == "string")
+    assert(schema.at("/properties/dateTime/format").asText() == "date-time")
+    assert(schema.at("/properties/dateTime/description").asText() == "This is description from @JsonPropertyDescription")
+    assert(schemaHTML5Date.at("/properties/dateTime/format").asText() == "datetime")
+    assert(schemaHTML5DateNullable.at("/properties/dateTime/oneOf/1/format").asText() == "datetime")
+
+
+    assert(schema.at("/properties/dateTimeWithAnnotation/type").asText() == "string")
+    assert(schema.at("/properties/dateTimeWithAnnotation/format").asText() == "text")
 
     // Make sure autoGenerated title is correct
-    assert( schemaHTML5Date.at("/properties/dateTimeWithAnnotation/title").asText() == "Date Time With Annotation")
-
-
+    assert(schemaHTML5Date.at("/properties/dateTimeWithAnnotation/title").asText() == "Date Time With Annotation")
   }
 
   test("scala using option with HTML5") {
     val jsonNode = assertToFromJson(jsonSchemaGeneratorScalaHTML5, testData.pojoUsingOptionScala)
     val schema = generateAndValidateSchema(jsonSchemaGeneratorScalaHTML5, testData.pojoUsingOptionScala.getClass, Some(jsonNode))
 
-    assert(schema.at("/properties/_string/oneOf/0/type").asText() == "null")
-    assert(schema.at("/properties/_string/oneOf/0/title").asText() == "Not included")
-    assert(schema.at("/properties/_string/oneOf/1/type").asText() == "string")
-    assert(!getRequiredList(schema).contains("_string")) // Should allow null by default
+    assertNullableType(schema, "/properties/_string", "string")
     assert(schema.at("/properties/_string/title").asText() == "_string")
 
-    assert(schema.at("/properties/_integer/oneOf/0/type").asText() == "null")
-    assert(schema.at("/properties/_integer/oneOf/0/title").asText() == "Not included")
-    assert(schema.at("/properties/_integer/oneOf/1/type").asText() == "integer")
-    assert(!getRequiredList(schema).contains("_integer")) // Should allow null by default
+    assertNullableType(schema, "/properties/_integer", "integer")
     assert(schema.at("/properties/_integer/title").asText() == "_integer")
 
-    assert(schema.at("/properties/_boolean/oneOf/0/type").asText() == "null")
-    assert(schema.at("/properties/_boolean/oneOf/0/title").asText() == "Not included")
-    assert(schema.at("/properties/_boolean/oneOf/1/type").asText() == "boolean")
-    assert(!getRequiredList(schema).contains("_boolean")) // Should allow null by default
+    assertNullableType(schema, "/properties/_boolean", "boolean")
     assert(schema.at("/properties/_boolean/title").asText() == "_boolean")
 
-    assert(schema.at("/properties/_double/oneOf/0/type").asText() == "null")
-    assert(schema.at("/properties/_double/oneOf/0/title").asText() == "Not included")
-    assert(schema.at("/properties/_double/oneOf/1/type").asText() == "number")
-    assert(!getRequiredList(schema).contains("_double")) // Should allow null by default
+    assertNullableType(schema, "/properties/_double", "number")
     assert(schema.at("/properties/_double/title").asText() == "_double")
 
     assert(schema.at("/properties/child1/oneOf/0/type").asText() == "null")
@@ -575,10 +747,10 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     assert(schema.at("/properties/child1/title").asText() == "Child 1")
 
     assertJsonSubTypesInfo(child1, "type", "child1")
-    assert( child1.at("/properties/parentString/type").asText() == "string" )
-    assert( child1.at("/properties/child1String/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String2/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String3/type").asText() == "string" )
+    assert(child1.at("/properties/parentString/type").asText() == "string")
+    assert(child1.at("/properties/child1String/type").asText() == "string")
+    assert(child1.at("/properties/_child1String2/type").asText() == "string")
+    assert(child1.at("/properties/_child1String3/type").asText() == "string")
 
     assert(schema.at("/properties/optionalList/oneOf/0/type").asText() == "null")
     assert(schema.at("/properties/optionalList/oneOf/0/title").asText() == "Not included")
@@ -591,18 +763,11 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     val jsonNode = assertToFromJson(jsonSchemaGeneratorHTML5, testData.pojoUsingOptionalJava)
     val schema = generateAndValidateSchema(jsonSchemaGeneratorHTML5, testData.pojoUsingOptionalJava.getClass, Some(jsonNode))
 
-    assert(schema.at("/properties/_string/oneOf/0/type").asText() == "null")
-    assert(schema.at("/properties/_string/oneOf/0/title").asText() == "Not included")
-    assert(schema.at("/properties/_string/oneOf/1/type").asText() == "string")
-    assert(!getRequiredList(schema).contains("_string")) // Should allow null by default
+    assertNullableType(schema, "/properties/_string", "string")
     assert(schema.at("/properties/_string/title").asText() == "_string")
 
-    assert(schema.at("/properties/_integer/oneOf/0/type").asText() == "null")
-    assert(schema.at("/properties/_integer/oneOf/0/title").asText() == "Not included")
-    assert(schema.at("/properties/_integer/oneOf/1/type").asText() == "integer")
-    assert(!getRequiredList(schema).contains("_integer")) // Should allow null by default
+    assertNullableType(schema, "/properties/_integer", "integer")
     assert(schema.at("/properties/_integer/title").asText() == "_integer")
-
 
     assert(schema.at("/properties/child1/oneOf/0/type").asText() == "null")
     assert(schema.at("/properties/child1/oneOf/0/title").asText() == "Not included")
@@ -610,14 +775,37 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     assert(schema.at("/properties/child1/title").asText() == "Child 1")
 
     assertJsonSubTypesInfo(child1, "type", "child1")
-    assert( child1.at("/properties/parentString/type").asText() == "string" )
-    assert( child1.at("/properties/child1String/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String2/type").asText() == "string" )
-    assert( child1.at("/properties/_child1String3/type").asText() == "string" )
+    assert(child1.at("/properties/parentString/type").asText() == "string")
+    assert(child1.at("/properties/child1String/type").asText() == "string")
+    assert(child1.at("/properties/_child1String2/type").asText() == "string")
+    assert(child1.at("/properties/_child1String3/type").asText() == "string")
 
-    assert(schema.at("/properties/optionalList/oneOf/0/type").asText() == "null")
-    assert(schema.at("/properties/optionalList/oneOf/0/title").asText() == "Not included")
-    assert(schema.at("/properties/optionalList/oneOf/1/type").asText() == "array")
+    assertNullableType(schema, "/properties/optionalList", "array")
+    assert(schema.at("/properties/optionalList/oneOf/1/items/$ref").asText() == "#/definitions/ClassNotExtendingAnything")
+    assert(schema.at("/properties/optionalList/title").asText() == "Optional List")
+  }
+
+  test("java using optional with HTML5+nullable") {
+    val jsonNode = assertToFromJson(jsonSchemaGeneratorHTML5Nullable, testData.pojoUsingOptionalJava)
+    val schema = generateAndValidateSchema(jsonSchemaGeneratorHTML5Nullable, testData.pojoUsingOptionalJava.getClass, Some(jsonNode))
+
+    assertNullableType(schema, "/properties/_string", "string")
+    assertNullableType(schema, "/properties/_integer", "integer")
+
+    assert(schema.at("/properties/child1/oneOf/0/type").asText() == "null")
+    assert(schema.at("/properties/child1/oneOf/0/title").asText() == "Not included")
+    val child1 = getNodeViaRefs(schema, schema.at("/properties/child1/oneOf/1"), "Child1")
+
+    assertJsonSubTypesInfo(child1, "type", "child1")
+    assertNullableType(child1, "/properties/parentString", "string")
+    assertNullableType(child1, "/properties/child1String", "string")
+    assertNullableType(child1, "/properties/_child1String2", "string")
+
+    // This is required as we have a @JsonProperty marking it as so.
+    assert(child1.at("/properties/_child1String3/type").asText() == "string")
+    assert(getRequiredList(child1).contains("_child1String3"))
+
+    assertNullableType(schema, "/properties/optionalList", "array")
     assert(schema.at("/properties/optionalList/oneOf/1/items/$ref").asText() == "#/definitions/ClassNotExtendingAnything")
     assert(schema.at("/properties/optionalList/title").asText() == "Optional List")
   }
@@ -631,12 +819,28 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       assert(schema.at("/properties/myEnum/propertyOrder").asInt() == 2)
     }
 
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorHTML5Nullable, testData.classNotExtendingAnything)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorHTML5Nullable, testData.classNotExtendingAnything.getClass, Some(jsonNode))
+
+      assert(schema.at("/properties/someString/propertyOrder").asInt() == 1)
+      assert(schema.at("/properties/myEnum/propertyOrder").asInt() == 2)
+    }
+
     // Make sure propertyOrder is not enabled when not using html5
     {
       val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.classNotExtendingAnything)
       val schema = generateAndValidateSchema(jsonSchemaGenerator, testData.classNotExtendingAnything.getClass, Some(jsonNode))
 
-      assert(schema.at("/properties/someString/propertyOrder").isMissingNode == true)
+      assert(schema.at("/properties/someString/propertyOrder").isMissingNode)
+    }
+
+    // Same with the non-html5 nullable
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.classNotExtendingAnything)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.classNotExtendingAnything.getClass, Some(jsonNode))
+
+      assert(schema.at("/properties/someString/propertyOrder").isMissingNode)
     }
   }
 
@@ -689,18 +893,45 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       assertChild1(schema, "/oneOf", defName = "MixinChild1")
       assertChild2(schema, "/oneOf", defName = "MixinChild2")
     }
+
+    // Java + Nullable types
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.mixinChild1)
+      assertToFromJson(jsonSchemaGeneratorNullable, testData.mixinChild1, classOf[MixinParent])
+
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, classOf[MixinParent], Some(jsonNode))
+
+      assertNullableChild1(schema, "/oneOf", defName = "MixinChild1")
+      assertNullableChild2(schema, "/oneOf", defName = "MixinChild2")
+    }
   }
 
   test("issue 24") {
-    val entityWrapperSchema = jsonSchemaGenerator.generateJsonSchema(classOf[EntityWrapper])
+    jsonSchemaGenerator.generateJsonSchema(classOf[EntityWrapper])
+    jsonSchemaGeneratorNullable.generateJsonSchema(classOf[EntityWrapper])
   }
 
   test("Polymorphism oneOf-ordering") {
     val schema = generateAndValidateSchema(jsonSchemaGeneratorScalaHTML5, classOf[PolymorphismOrderingParentScala], None)
     val oneOfList:List[String] = schema.at("/oneOf").asInstanceOf[ArrayNode].iterator().asScala.toList.map(_.at("/$ref").asText)
-    assert( List("#/definitions/PolymorphismOrderingChild3", "#/definitions/PolymorphismOrderingChild1", "#/definitions/PolymorphismOrderingChild4", "#/definitions/PolymorphismOrderingChild2") == oneOfList)
+    assert(List("#/definitions/PolymorphismOrderingChild3", "#/definitions/PolymorphismOrderingChild1", "#/definitions/PolymorphismOrderingChild4", "#/definitions/PolymorphismOrderingChild2") == oneOfList)
   }
 
+  test("@NotNull annotations and nullable types") {
+    val jsonNode = assertToFromJson(jsonSchemaGeneratorNullable, testData.notNullableButNullBoolean)
+    val schema = generateAndValidateSchema(jsonSchemaGeneratorNullable, testData.notNullableButNullBoolean.getClass, None)
+
+    val exception = intercept[Exception] {
+      useSchema(schema, Some(jsonNode))
+    }
+
+    // While our compiler will let us do what we're about to do, the validator should give us a message that looks like this...
+    assert(exception.getMessage.contains("json does not validate against schema"))
+    assert(exception.getMessage.contains("error: instance type (null) does not match any allowed primitive type (allowed: [\"boolean\"])"))
+
+    assert(schema.at("/properties/notNullBooleanObject/type").asText() == "boolean")
+    assert(getRequiredList(schema).contains("notNullBooleanObject"))
+  }
 }
 
 trait TestData {
@@ -747,6 +978,8 @@ trait TestData {
   val classNotExtendingAnythingScala = ClassNotExtendingAnythingScala("Something", MyEnum.C, Some(MyEnum.A))
 
   val manyPrimitives = new ManyPrimitives("s1", 1, 2, true, false, true, 0.1, 0.2, MyEnum.B)
+
+  val manyPrimitivesNulls = new ManyPrimitives(null, null, 1, null, false, false, null, 0.1, null)
 
   val manyPrimitivesScala = ManyPrimitivesScala("s1", 1, true, 0.1)
 
@@ -806,25 +1039,7 @@ trait TestData {
     c.child1String3 = "cs3"
     c
   }
+
+  // Test the collision of @NotNull validations and null fields.
+  val notNullableButNullBoolean = new PojoWithNotNull(null)
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithNotNull.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoWithNotNull.java
@@ -1,0 +1,37 @@
+package com.kjetland.jackson.jsonSchema.testData;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Provides our tests with a simple class: a single field with a {@link javax.validation.constraints.NotNull} annotation
+ * set upon a type that is, theoretically nullable.
+ * <p>
+ * The compiler should allow us to do this, but the schema should then fail to validate.
+ */
+public class PojoWithNotNull {
+    @NotNull
+    public Boolean notNullBooleanObject;
+
+    public PojoWithNotNull() {
+
+    }
+
+    public PojoWithNotNull(Boolean notNullBooleanObject) {
+        this.notNullBooleanObject = notNullBooleanObject;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final PojoWithNotNull that = (PojoWithNotNull) o;
+
+        return notNullBooleanObject != null ? notNullBooleanObject.equals(that.notNullBooleanObject) : that.notNullBooleanObject == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return notNullBooleanObject != null ? notNullBooleanObject.hashCode() : 0;
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/mixin/MixinParent.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/mixin/MixinParent.java
@@ -1,8 +1,5 @@
 package com.kjetland.jackson.jsonSchema.testData.mixin;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 public abstract class MixinParent {
 
     public String parentString;


### PR DESCRIPTION
 * Introduce `useOneOfForNullables` configuration option (default: `false`)
 * If `true`, will allow naked nullable types (non-optional, non-primitive) types to be null in the schema
 * This complements the `useOneOfForOption` option, and has similar schema output
 * Introduce `nullableJsonSchemaDraft4` - a default schema config with both `useOneOfForNullables` and `useOneOfForOption` enabled
 * Add README section on nullable types in Java
 * Supplement tests to cover new nullable types
 * Minor cleanups (spacing consistency, unused imports etc)

Please note that much like `useOneOfForOption`, you can disallow null for your property by marking it `@JsonProperty` with a "required" set to true, or using `@NotNull`

[Close #30]