### PR TITLE
Add jsonSupplier for even more flixibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,32 @@ public class MyPojo {
     ...
 }
 ```
+If a part of the schema is not known at compile time, you can use a json supplier:
+```Scala
+case class MyPojo {
+  @JsonSchemaInject(jsonSupplier = classOf[UserNamesLoader])
+  uns:Set[String]
+  ...
+  ...
+  ...
+}
+
+class UserNamesLoader extends Supplier[JsonNode] {
+  val _objectMapper = new ObjectMapper()
+
+  override def get(): JsonNode = {
+    val schema = _objectMapper.createObjectNode()
+    val values = schema.putObject("items").putArray("enum")
+    loadUsers().foreach(u => values.add(u.name))
+
+    schema
+  }
+  ...
+  ...
+  ...
+}
+```
+This will associate an enum of possible values for the set that you generate at runtime.
 
 @JsonSchemaInject can also be used on properties.
 

--- a/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaInject.java
+++ b/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaInject.java
@@ -1,7 +1,10 @@
 package com.kjetland.jackson.jsonSchema.annotations;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.concurrent.Callable;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -31,5 +34,17 @@ public @interface JsonSchemaInject {
      * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link #json()}
      */
     JsonSchemaBool[] bools() default {};
+
+    /**
+     * @return a class that supplies a raw json
+     */
+    Class<? extends Callable<JsonNode>> jsonSupplier() default None.class;
+
+    class None implements Callable<JsonNode> {
+        @Override
+        public JsonNode call() throws Exception {
+            return null;
+        }
+    }
 }
 

--- a/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaInject.java
+++ b/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaInject.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -21,28 +21,28 @@ public @interface JsonSchemaInject {
     String json() default "{}";
 
     /**
-     * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link #json()}
+     * @return a class for supplier of a raw json. The json gets applied after {@link #json()}.
+     */
+    Class<? extends Supplier<JsonNode>> jsonSupplier() default None.class;
+
+    /**
+     * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link #jsonSupplier()}
      */
     JsonSchemaString[] strings() default {};
 
     /**
-     * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link #json()}
+     * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link #jsonSupplier()
      */
     JsonSchemaInt[] ints() default {};
 
     /**
-     * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link #json()}
+     * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link #jsonSupplier()
      */
     JsonSchemaBool[] bools() default {};
 
-    /**
-     * @return a class that supplies a raw json
-     */
-    Class<? extends Callable<JsonNode>> jsonSupplier() default None.class;
-
-    class None implements Callable<JsonNode> {
+    class None implements Supplier<JsonNode> {
         @Override
-        public JsonNode call() throws Exception {
+        public JsonNode get() {
             return null;
         }
     }

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -732,6 +732,9 @@ class JsonSchemaGenerator
               a =>
                 // Must parse json
                 val injectJsonNode = objectMapper.readTree(a.json())
+                Option(a.jsonSupplier())
+                  .flatMap(cls => Option(cls.newInstance().call()))
+                  .foreach(json => merge(injectJsonNode, json))
                 a.strings().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))
                 a.ints().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))
                 a.bools().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))
@@ -940,6 +943,9 @@ class JsonSchemaGenerator
                   a =>
                     // Must parse json
                     val injectJsonNode = objectMapper.readTree(a.json())
+                    Option(a.jsonSupplier())
+                      .flatMap(cls => Option(cls.newInstance().call()))
+                      .foreach(json => merge(injectJsonNode, json))
                     a.strings().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))
                     a.ints().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))
                     a.bools().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.jsonFormatVisitors._
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass
-import com.fasterxml.jackson.databind.jsontype.NamedType
 import com.fasterxml.jackson.databind.node.{ArrayNode, JsonNodeFactory, ObjectNode}
 import com.kjetland.jackson.jsonSchema.annotations._
 import org.reflections.Reflections
@@ -733,7 +732,7 @@ class JsonSchemaGenerator
                 // Must parse json
                 val injectJsonNode = objectMapper.readTree(a.json())
                 Option(a.jsonSupplier())
-                  .flatMap(cls => Option(cls.newInstance().call()))
+                  .flatMap(cls => Option(cls.newInstance().get()))
                   .foreach(json => merge(injectJsonNode, json))
                 a.strings().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))
                 a.ints().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))
@@ -944,7 +943,7 @@ class JsonSchemaGenerator
                     // Must parse json
                     val injectJsonNode = objectMapper.readTree(a.json())
                     Option(a.jsonSupplier())
-                      .flatMap(cls => Option(cls.newInstance().call()))
+                      .flatMap(cls => Option(cls.newInstance().get()))
                       .foreach(json => merge(injectJsonNode, json))
                     a.strings().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))
                     a.ints().foreach(v => injectJsonNode.visit(v.path(), (o, n) => o.put(n, v.value())))

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -1039,6 +1039,8 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       assert(schema.at("/properties/ib/type").asText() == "integer")
       assert(schema.at("/properties/ib/multipleOf").asInt() == 7)
       assert(schema.at("/properties/ib/exclusiveMinimum").asBoolean())
+      assert(schema.at("/properties/uns/items/enum/0").asText() == "foo")
+      assert(schema.at("/properties/uns/items/enum/1").asText() == "bar")
     }
   }
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/UsingJsonSchemaInject.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/UsingJsonSchemaInject.scala
@@ -1,7 +1,10 @@
 package com.kjetland.jackson.jsonSchema.testDataScala
 
+import java.util.function.Supplier
 import javax.validation.constraints.Min
 
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaBool, JsonSchemaInject, JsonSchemaInt, JsonSchemaString}
 
 
@@ -36,8 +39,25 @@ case class UsingJsonSchemaInject
     ints = Array(new JsonSchemaInt(path = "multipleOf", value = 7))
   )
   @Min(5)
-  ib:Int
+  ib:Int,
+
+  @JsonSchemaInject(jsonSupplier = classOf[UserNamesLoader])
+  uns:Set[String]
 )
+
+class UserNamesLoader extends Supplier[JsonNode] {
+  val _objectMapper = new ObjectMapper()
+
+  override def get(): JsonNode = {
+    val schema = _objectMapper.createObjectNode()
+    val values = schema.putObject("items").putArray("enum")
+    values.add("foo")
+    values.add("bar")
+
+    schema
+  }
+}
+  
 
 
 


### PR DESCRIPTION
Hey Morten, what do think about this change? That's for a use case when the content of a json enum may not be know at the compile time, e.g. it needs to be loaded from db:

```
    public static class JsonSchemaSupplier implements Callable<JsonNode> {
        @Override
        public JsonNode call() throws Exception {
            final ObjectNode schema = mapper.createObjectNode();
            final ArrayNode values = schema.putObject("items").putArray("enum");
            for (User u : loadAllUsers()) {
                values.add(u.name());
            }
            return schema;
        }
    }
```

If you have no objections, I could set up the tests for it.