### PR TITLE
add support for @Pattern.List validation annotation

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -343,6 +343,14 @@ class JsonSchemaGenerator
               node.put("pattern", pattern.regexp())
           }
 
+          // Look for @Pattern.List
+          Option(p.getAnnotation(classOf[Pattern.List])).map {
+            patterns => {
+              val regex = patterns.value().map(_.regexp).foldLeft("^")(_ + "(?=" + _ + ")").concat(".*$")
+              node.put("pattern", regex)
+            }
+          }
+
           // Look for @JsonSchemaDefault
           Option(p.getAnnotation(classOf[JsonSchemaDefault])).map {
             defaultValue =>

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -925,6 +925,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     assert(schema.at("/properties/stringUsingSizeOnlyMax/minLength").isMissingNode)
 
     assert(schema.at("/properties/stringUsingPattern/pattern").asText() == "_stringUsingPatternA|_stringUsingPatternB")
+    assert(schema.at("/properties/stringUsingPatternList/pattern").asText() == "^(?=^_stringUsing.*)(?=.*PatternList$).*$")
 
     assert(schema.at("/properties/intMin/minimum").asInt() == 1)
     assert(schema.at("/properties/intMax/maximum").asInt() == 10)
@@ -1308,7 +1309,7 @@ trait TestData {
   val manyDates = ManyDates(LocalDateTime.now(), OffsetDateTime.now(), LocalDate.now(), org.joda.time.LocalDate.now())
 
   val classUsingValidation = ClassUsingValidation(
-    "_stringUsingNotNull", "_stringUsingSize", "_stringUsingSizeOnlyMin", "_stringUsingSizeOnlyMax", "_stringUsingPatternA",
+    "_stringUsingNotNull", "_stringUsingSize", "_stringUsingSizeOnlyMin", "_stringUsingSizeOnlyMax", "_stringUsingPatternA", "_stringUsingPatternList",
     1, 2, 1.0, 2.0
   )
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/ClassUsingValidation.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/ClassUsingValidation.scala
@@ -19,6 +19,12 @@ case class ClassUsingValidation
   @Pattern(regexp = "_stringUsingPatternA|_stringUsingPatternB")
   stringUsingPattern:String,
 
+  @Pattern.List(Array(
+    new Pattern(regexp = "^_stringUsing.*"),
+    new Pattern(regexp = ".*PatternList$")
+  ))
+  stringUsingPatternList:String,
+
   @Min(1)
   intMin:Int,
   @Max(10)


### PR DESCRIPTION
Adds support for a list of @​Pattern annotations
I've ended up needing this at work, where there is a list of regex patterns that must be fulfilled on a string (essentially 1 generic pattern (e.g. 9 numbers) and 5 others saying that e.g. must not start with 9, must not be 123456789, must not end be 9 of the same numbers etc.

I've been testing, and the separate conditions fulfilled by javax validation could be supported in a single regex by merging them together with AND conditions: `^(?={condition1})(?={condition2}).*$`

This is the first time writing scala from a java background, so I apologise if I'm not following standard patterns.