### PR TITLE
Added null schema for null formats and refined content type detection of map-like structures

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -523,6 +523,7 @@ class JsonSchemaGenerator
 
     override def expectNullFormat(_type: JavaType) = {
       l(s"expectNullFormat - _type: ${_type}")
+      node.put("type", "null")
       new JsonNullFormatVisitor {}
     }
 
@@ -565,7 +566,7 @@ class JsonSchemaGenerator
       definitionsHandler.pushWorkInProgress()
 
       val childVisitor = createChild(additionalPropsObject, None)
-      objectMapper.acceptJsonFormatVisitor(tryToReMapType(_type.containedType(1)), childVisitor)
+      objectMapper.acceptJsonFormatVisitor(tryToReMapType(_type.getContentType), childVisitor)
       definitionsHandler.popworkInProgress()
 
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -2,7 +2,7 @@ package com.kjetland.jackson.jsonSchema
 
 import java.time.{LocalDate, LocalDateTime, OffsetDateTime}
 import java.util
-import java.util.{Optional, TimeZone}
+import java.util.{Collections, Optional, TimeZone}
 
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.node.{ArrayNode, MissingNode, ObjectNode}
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.datatype.joda.JodaModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.github.fge.jsonschema.main.JsonSchemaFactory
+import com.kjetland.jackson.jsonSchema.testData.GenericClass.GenericClassVoid
+import com.kjetland.jackson.jsonSchema.testData.MapLike.GenericMapLike
 import com.kjetland.jackson.jsonSchema.testData._
 import com.kjetland.jackson.jsonSchema.testData.mixin.{MixinChild1, MixinModule, MixinParent}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism1.{Child1, Child2, Parent}
@@ -225,6 +227,21 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       assert(schema.at("/properties/myEnum/type").asText() == "string")
       assert(getArrayNodeAsListOfStrings(schema.at("/properties/myEnum/enum")) == enumList)
       assert(getArrayNodeAsListOfStrings(schema.at("/properties/myEnumO/enum")) == enumList)
+    }
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorScala, testData.genericClassVoid)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorScala, testData.genericClassVoid.getClass, Some(jsonNode))
+      assert(schema.at("/type").asText() == "object")
+      assert(!schema.at("/additionalProperties").asBoolean())
+      assert(schema.at("/properties/content/type").asText() == "null")
+      assert(schema.at("/properties/list/type").asText() == "array")
+      assert(schema.at("/properties/list/items/type").asText() == "null")
+    }
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGeneratorScala, testData.genericMapLike)
+      val schema = generateAndValidateSchema(jsonSchemaGeneratorScala, testData.genericMapLike.getClass, Some(jsonNode))
+      assert(schema.at("/type").asText() == "object")
+      assert(schema.at("/additionalProperties/type").asText() == "string")
     }
   }
 
@@ -1369,4 +1386,9 @@ trait TestData {
   val notNullableButNullBoolean = new PojoWithNotNull(null)
 
   val nestedPolymorphism = NestedPolymorphism1_1("a1", NestedPolymorphism2_2("a2", Some(NestedPolymorphism3("b3"))))
+
+  val genericClassVoid = new GenericClassVoid()
+
+  val genericMapLike = new GenericMapLike(Collections.singletonMap("foo", "bar"))
+
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/GenericClass.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/GenericClass.java
@@ -1,0 +1,51 @@
+package com.kjetland.jackson.jsonSchema.testData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenericClass<T> {
+
+	private T content;
+
+	private List<T> list = new ArrayList<>();
+
+	public T getContent() {
+		return content;
+	}
+
+	public GenericClass<T> setContent(T content) {
+		this.content = content;
+		return this;
+	}
+
+	public List<T> getList() {
+		return list;
+	}
+
+	public GenericClass<T> setList(List<T> list) {
+		this.list = list;
+		return this;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		GenericClass<?> that = (GenericClass<?>) o;
+
+		return content != null ? content.equals(that.content) : that.content == null;
+	}
+
+	@Override
+	public int hashCode() {
+		return content != null ? content.hashCode() : 0;
+	}
+
+	public static class GenericClassVoid extends GenericClass<Void> {
+	}
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/MapLike.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/MapLike.java
@@ -1,0 +1,121 @@
+package com.kjetland.jackson.jsonSchema.testData;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+public interface MapLike<T> extends Map<String, String> {
+	void accept(T content);
+
+	@JsonDeserialize(using = MyDeserializer.class)
+	class GenericMapLike implements MapLike<MyEnum> {
+
+		private final Map<String, String> innerMap;
+
+		public GenericMapLike(Map<String, String> innerMap) {
+			this.innerMap = new LinkedHashMap<>(innerMap);
+		}
+
+		@Override
+		public void accept(MyEnum content) {
+			innerMap.put(content.name(), content.name());
+		}
+
+		@Override
+		public int size() {
+			return innerMap.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return innerMap.isEmpty();
+		}
+
+		@Override
+		public boolean containsKey(Object key) {
+			return innerMap.containsKey(key);
+		}
+
+		@Override
+		public boolean containsValue(Object value) {
+			return innerMap.containsValue(value);
+		}
+
+		@Override
+		public String get(Object key) {
+			return innerMap.get(key);
+		}
+
+		@Override
+		public String put(String key, String value) {
+			return innerMap.put(key, value);
+		}
+
+		@Override
+		public String remove(Object key) {
+			return innerMap.remove(key);
+		}
+
+		@Override
+		public void putAll(Map<? extends String, ? extends String> m) {
+			innerMap.putAll(m);
+		}
+
+		@Override
+		public void clear() {
+			innerMap.clear();
+		}
+
+		@Override
+		public Set<String> keySet() {
+			return innerMap.keySet();
+		}
+
+		@Override
+		public Collection<String> values() {
+			return innerMap.values();
+		}
+
+		@Override
+		public Set<Entry<String, String>> entrySet() {
+			return innerMap.entrySet();
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			GenericMapLike that = (GenericMapLike) o;
+
+			return innerMap.equals(that.innerMap);
+		}
+
+		@Override
+		public int hashCode() {
+			return innerMap.hashCode();
+		}
+	}
+
+	class MyDeserializer extends JsonDeserializer<GenericMapLike> {
+		@Override
+		public GenericMapLike deserialize(JsonParser p, DeserializationContext ctxt)
+				throws IOException, JsonProcessingException
+		{
+			Map<String, String> map = p.readValueAs(Map.class);
+			return new GenericMapLike(map);
+		}
+	}
+}


### PR DESCRIPTION
the former is required for correct `Void` handling the latter for correct handling of custom map-like types.