### PR TITLE
Update to javax.validation 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Code - Using Java
     // If using JsonSchema to generate HTML5 GUI:
     // JsonSchemaGenerator html5 = new JsonSchemaGenerator(objectMapper, JsonSchemaConfig.html5EnabledSchema() );
 
-    // If you want to confioure it manually:
+    // If you want to configure it manually:
     // JsonSchemaConfig config = JsonSchemaConfig.create(...);
     // JsonSchemaGenerator generator = new JsonSchemaGenerator(objectMapper, config);
 
@@ -320,8 +320,8 @@ Here is how to do it in Scala:
 ```scala
     val objectMapper = new ObjectMapper
 
-    objectMapper.disable(MapperFeature.DEFAULT_VIEW_INCLUSION);
-    objectMapper.setConfig(objectMapper.getSerializationConfig().withView(Views.MyView.class));
+    objectMapper.disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+    objectMapper.setConfig(objectMapper.getSerializationConfig().withView(Views.MyView.class))
 
     val jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper)
     val jsonSchema:JsonNode = jsonSchemaGenerator.generateJsonSchema(classOf[YourPOJO])

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ val slf4jVersion = "1.7.7"
 
 lazy val deps  = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-  "javax.validation" % "validation-api" % "1.1.0.Final",
+  "javax.validation" % "validation-api" % "2.0.1.Final",
   "org.slf4j" % "slf4j-api" % slf4jVersion,
   "io.github.lukehutch" % "fast-classpath-scanner" % "2.0.20",
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",

--- a/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaFormat.java
+++ b/src/main/java/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaFormat.java
@@ -4,7 +4,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.*;
-import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Target({ METHOD, FIELD, PARAMETER, TYPE })

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -226,7 +226,7 @@ class JsonSchemaGenerator
 
   case class DefinitionInfo(ref:Option[String], jsonObjectFormatVisitor: Option[JsonObjectFormatVisitor])
 
-  // Class that manages creating new defenitions or getting $refs to existing definitions
+  // Class that manages creating new definitions or getting $refs to existing definitions
   class DefinitionsHandler() {
     private var class2Ref = Map[Class[_], String]()
     private val definitionsNode = JsonNodeFactory.instance.objectNode()
@@ -446,7 +446,7 @@ class JsonSchemaGenerator
 
       node.put("type", "number")
 
-      // Look for @Min, @Max => minumum, maximum
+      // Look for @Min, @Max => minimum, maximum
       currentProperty.map {
         p =>
           Option(p.getAnnotation(classOf[Min])).map {
@@ -491,7 +491,7 @@ class JsonSchemaGenerator
 
       node.put("type", "integer")
 
-      // Look for @Min, @Max => minumum, maximum
+      // Look for @Min, @Max => minimum, maximum
       currentProperty.map {
         p =>
           Option(p.getAnnotation(classOf[Min])).map {
@@ -601,7 +601,7 @@ class JsonSchemaGenerator
 
     private def extractPolymorphismInfo(_type:JavaType):Option[PolymorphismInfo] = {
       // look for @JsonTypeInfo
-      val ac = AnnotatedClass.construct(_type, objectMapper.getDeserializationConfig())
+      val ac = AnnotatedClass.construct(_type, objectMapper.getDeserializationConfig)
       Option(ac.getAnnotations.get(classOf[JsonTypeInfo])).map {
         jsonTypeInfo =>
 
@@ -634,7 +634,7 @@ class JsonSchemaGenerator
 
     private def extractSubTypes(_type: JavaType):List[Class[_]] = {
 
-      val ac = AnnotatedClass.construct(_type, objectMapper.getDeserializationConfig())
+      val ac = AnnotatedClass.construct(_type, objectMapper.getDeserializationConfig)
 
       Option(ac.getAnnotation(classOf[JsonTypeInfo])).map {
         jsonTypeInfo: JsonTypeInfo =>
@@ -762,7 +762,7 @@ class JsonSchemaGenerator
             thisObjectNode.put("additionalProperties", false)
 
             // If class is annotated with JsonSchemaFormat, we should add it
-            val ac = AnnotatedClass.construct(_type, objectMapper.getDeserializationConfig())
+            val ac = AnnotatedClass.construct(_type, objectMapper.getDeserializationConfig)
             resolvePropertyFormat(_type, objectMapper).foreach {
               format =>
                 setFormat(thisObjectNode, format)
@@ -1051,19 +1051,21 @@ class JsonSchemaGenerator
 
   private def merge(mainNode:JsonNode, updateNode:JsonNode):Unit = {
     val fieldNames = updateNode.fieldNames()
-    while (fieldNames.hasNext()) {
+    while (fieldNames.hasNext) {
 
       val fieldName = fieldNames.next()
       val jsonNode = mainNode.get(fieldName)
       // if field exists and is an embedded object
-      if (jsonNode != null && jsonNode.isObject()) {
+      if (jsonNode != null && jsonNode.isObject) {
         merge(jsonNode, updateNode.get(fieldName))
       }
       else {
-        if (mainNode.isInstanceOf[ObjectNode]) {
-          // Overwrite field
-          val value = updateNode.get(fieldName)
-          mainNode.asInstanceOf[ObjectNode].set(fieldName, value)
+        mainNode match {
+          case node: ObjectNode =>
+            // Overwrite field
+            val value = updateNode.get(fieldName)
+            node.set(fieldName, value)
+          case _ =>
         }
       }
 
@@ -1086,7 +1088,7 @@ class JsonSchemaGenerator
   }
 
   def resolvePropertyFormat(_type: JavaType, objectMapper:ObjectMapper):Option[String] = {
-    val ac = AnnotatedClass.construct(_type, objectMapper.getDeserializationConfig())
+    val ac = AnnotatedClass.construct(_type, objectMapper.getDeserializationConfig)
     resolvePropertyFormat(Option(ac.getAnnotation(classOf[JsonSchemaFormat])), _type.getRawClass.getName)
   }
 


### PR DESCRIPTION
* Upgrade dependency on javax.validation from `1.1.0.Final` to `2.0.1.Final` (no transitive dependencies in either)
* Minor typo fixes in Java/Scala/markdown files
* Very slight refactoring suggestions from IDEA:
    * Removed extra parent method calls with no arguments
    * Swapped an `isInstanceOf` to pattern matching

Closes mbknor/mbknor-jackson-jsonSchema#53