### PR TITLE
Add support for `@NotEmpty` annotation:

### DIFF
--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -983,6 +983,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       verifyStringProperty(schema, "stringUsingNotNull", Some(1), None, None, required = true)
       verifyStringProperty(schema, "stringUsingNotBlank", Some(1), None, Some("^.*\\S+.*$"), required = true)
       verifyStringProperty(schema, "stringUsingNotBlankAndNotNull", Some(1), None, Some("^.*\\S+.*$"), required = true)
+      verifyStringProperty(schema, "stringUsingNotEmpty", Some(1), None, None, required = true)
       verifyStringProperty(schema, "stringUsingSize", Some(1), Some(20), None, required = false)
       verifyStringProperty(schema, "stringUsingSizeOnlyMin", Some(1), None, None, required = false)
       verifyStringProperty(schema, "stringUsingSizeOnlyMax", None, Some(30), None, required = false)
@@ -993,6 +994,10 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       verifyNumericProperty(schema, "intMax", None, Some(10), required = true)
       verifyNumericProperty(schema, "doubleMin", Some(1), None, required = true)
       verifyNumericProperty(schema, "doubleMax", None, Some(10), required = true)
+
+      verifyArrayProperty(schema, "notEmptyStringArray", Some(1), None, required = true)
+
+      verifyObjectProperty(schema, "notEmptyMap", "string", Some(1), None, required = true)
     }
 
     // Java
@@ -1003,6 +1008,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       verifyStringProperty(schema, "stringUsingNotNull", Some(1), None, None, required = true)
       verifyStringProperty(schema, "stringUsingNotBlank", Some(1), None, Some("^.*\\S+.*$"), required = true)
       verifyStringProperty(schema, "stringUsingNotBlankAndNotNull", Some(1), None, Some("^.*\\S+.*$"), required = true)
+      verifyStringProperty(schema, "stringUsingNotEmpty", Some(1), None, None, required = true)
       verifyStringProperty(schema, "stringUsingSize", Some(1), Some(20), None, required = false)
       verifyStringProperty(schema, "stringUsingSizeOnlyMin", Some(1), None, None, required = false)
       verifyStringProperty(schema, "stringUsingSizeOnlyMax", None, Some(30), None, required = false)
@@ -1013,6 +1019,11 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       verifyNumericProperty(schema, "intMax", None, Some(10), required = true)
       verifyNumericProperty(schema, "doubleMin", Some(1), None, required = true)
       verifyNumericProperty(schema, "doubleMax", None, Some(10), required = true)
+
+      verifyArrayProperty(schema, "notEmptyStringArray", Some(1), None, required = true)
+      verifyArrayProperty(schema, "notEmptyStringList", Some(1), None, required = true)
+
+      verifyObjectProperty(schema, "notEmptyStringMap", "string", Some(1), None, required = true)
     }
 
     def verifyStringProperty(schema:JsonNode, propertyName:String, minLength:Option[Int], maxLength:Option[Int], pattern:Option[String], required:Boolean): Unit = {
@@ -1031,6 +1042,19 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     def verifyNumericProperty(schema:JsonNode, propertyName:String, minimum:Option[Int], maximum:Option[Int], required:Boolean): Unit = {
       assertNumericPropertyValidation(schema, propertyName, "minimum", minimum)
       assertNumericPropertyValidation(schema, propertyName, "maximum", maximum)
+      assertPropertyRequired(schema, propertyName, required)
+    }
+
+    def verifyArrayProperty(schema:JsonNode, propertyName:String, minItems:Option[Int], maxItems:Option[Int], required:Boolean): Unit = {
+      assertNumericPropertyValidation(schema, propertyName, "minItems", minItems)
+      assertNumericPropertyValidation(schema, propertyName, "maxItems", maxItems)
+      assertPropertyRequired(schema, propertyName, required)
+    }
+
+    def verifyObjectProperty(schema:JsonNode, propertyName:String, additionalPropertiesType:String, minProperties:Option[Int], maxProperties:Option[Int], required:Boolean): Unit = {
+      assert(schema.at(s"/properties/$propertyName/additionalProperties/type").asText() == additionalPropertiesType)
+      assertNumericPropertyValidation(schema, propertyName, "minProperties", minProperties)
+      assertNumericPropertyValidation(schema, propertyName, "maxProperties", maxProperties)
       assertPropertyRequired(schema, propertyName, required)
     }
 
@@ -1417,13 +1441,15 @@ trait TestData {
   val manyDates = ManyDates(LocalDateTime.now(), OffsetDateTime.now(), LocalDate.now(), org.joda.time.LocalDate.now())
 
   val classUsingValidation = ClassUsingValidation(
-    "_stringUsingNotNull", "_stringUsingNotBlank", "_stringUsingNotBlankAndNotNull", "_stringUsingSize", "_stringUsingSizeOnlyMin",
-    "_stringUsingSizeOnlyMax", "_stringUsingPatternA", "_stringUsingPatternList", 1, 2, 1.0, 2.0
+    "_stringUsingNotNull", "_stringUsingNotBlank", "_stringUsingNotBlankAndNotNull", "_stringUsingNotEmpty", List("l1", "l2", "l3"), Map("mk1" -> "mv1", "mk2" -> "mv2"),
+    "_stringUsingSize", "_stringUsingSizeOnlyMin", "_stringUsingSizeOnlyMax", "_stringUsingPatternA", "_stringUsingPatternList",
+    1, 2, 1.0, 2.0
   )
 
   val pojoUsingValidation = new PojoUsingValidation(
-    "_stringUsingNotNull", "_stringUsingNotBlank", "_stringUsingNotBlankAndNotNull", "_stringUsingSize", "_stringUsingSizeOnlyMin",
-    "_stringUsingSizeOnlyMax", "_stringUsingPatternA", "_stringUsingPatternList", 1, 2, 1.0, 2.0
+    "_stringUsingNotNull", "_stringUsingNotBlank", "_stringUsingNotBlankAndNotNull", "_stringUsingNotEmpty", Array("a1", "a2", "a3"), List("l1", "l2", "l3").asJava,
+    Map("mk1" -> "mv1", "mk2" -> "mv2").asJava, "_stringUsingSize", "_stringUsingSizeOnlyMin", "_stringUsingSizeOnlyMax", "_stringUsingPatternA",
+    "_stringUsingPatternList", 1, 2, 1.0, 2.0
   )
 
   val mixinChild1 = {

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingValidation.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingValidation.java
@@ -5,9 +5,13 @@ import com.kjetland.jackson.jsonSchema.testDataScala.ClassUsingValidation;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -26,6 +30,18 @@ public class PojoUsingValidation {
     @NotNull
     @NotBlank
     public String stringUsingNotBlankAndNotNull;
+
+    @NotEmpty
+    public String stringUsingNotEmpty;
+
+    @NotEmpty
+    public String[] notEmptyStringArray;
+
+    @NotEmpty
+    public List<String> notEmptyStringList;
+
+    @NotEmpty
+    public Map<String, String> notEmptyStringMap;
 
     @Size(min = 1, max = 20)
     public String stringUsingSize;
@@ -61,13 +77,17 @@ public class PojoUsingValidation {
 
     }
 
-    public PojoUsingValidation(final String stringUsingNotNull, final String stringUsingNotBlank, final String stringUsingNotBlankAndNotNull,
-                               final String stringUsingSize, final String stringUsingSizeOnlyMin, final String stringUsingSizeOnlyMax,
-                               final String stringUsingPattern,final String stringUsingPatternList, final int intMin, final int intMax,
-                               final double doubleMin,final double doubleMax) {
+    public PojoUsingValidation(final String stringUsingNotNull,final String stringUsingNotBlank, final String stringUsingNotBlankAndNotNull, final String stringUsingNotEmpty,
+                               final String[] notEmptyStringArray, final List<String> notEmptyStringList, final Map<String, String> notEmptyStringMap,
+                               final String stringUsingSize,final String stringUsingSizeOnlyMin, final String stringUsingSizeOnlyMax, final String stringUsingPattern,
+                               final String stringUsingPatternList, final int intMin, final int intMax, final double doubleMin, final double doubleMax) {
         this.stringUsingNotNull = stringUsingNotNull;
         this.stringUsingNotBlank = stringUsingNotBlank;
         this.stringUsingNotBlankAndNotNull = stringUsingNotBlankAndNotNull;
+        this.stringUsingNotEmpty = stringUsingNotEmpty;
+        this.notEmptyStringArray = notEmptyStringArray;
+        this.notEmptyStringList = notEmptyStringList;
+        this.notEmptyStringMap = notEmptyStringMap;
         this.stringUsingSize = stringUsingSize;
         this.stringUsingSizeOnlyMin = stringUsingSizeOnlyMin;
         this.stringUsingSizeOnlyMax = stringUsingSizeOnlyMax;
@@ -95,6 +115,10 @@ public class PojoUsingValidation {
                 Objects.equals(stringUsingNotNull, that.stringUsingNotNull) &&
                 Objects.equals(stringUsingNotBlank, that.stringUsingNotBlank) &&
                 Objects.equals(stringUsingNotBlankAndNotNull, that.stringUsingNotBlankAndNotNull) &&
+                Objects.equals(stringUsingNotEmpty, that.stringUsingNotEmpty) &&
+                Arrays.equals(notEmptyStringArray, that.notEmptyStringArray) &&
+                Objects.equals(notEmptyStringList, that.notEmptyStringList) &&
+                Objects.equals(notEmptyStringMap, that.notEmptyStringMap) &&
                 Objects.equals(stringUsingSize, that.stringUsingSize) &&
                 Objects.equals(stringUsingSizeOnlyMin, that.stringUsingSizeOnlyMin) &&
                 Objects.equals(stringUsingSizeOnlyMax, that.stringUsingSizeOnlyMax) &&
@@ -104,9 +128,10 @@ public class PojoUsingValidation {
 
     @Override
     public int hashCode() {
-        return Objects
-                .hash(stringUsingNotNull, stringUsingNotBlank, stringUsingNotBlankAndNotNull, stringUsingSize,
-                        stringUsingSizeOnlyMin, stringUsingSizeOnlyMax, stringUsingPattern, stringUsingPatternList,
-                        intMin, intMax, doubleMin, doubleMax);
+
+        int result = Objects
+                .hash(stringUsingNotNull, stringUsingNotBlank, stringUsingNotBlankAndNotNull, stringUsingNotEmpty, notEmptyStringList, notEmptyStringMap, stringUsingSize, stringUsingSizeOnlyMin, stringUsingSizeOnlyMax, stringUsingPattern, stringUsingPatternList, intMin, intMax, doubleMin, doubleMax);
+        result = 31 * result + Arrays.hashCode(notEmptyStringArray);
+        return result;
     }
 }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/ClassUsingValidation.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testDataScala/ClassUsingValidation.scala
@@ -14,6 +14,15 @@ case class ClassUsingValidation
   @NotBlank
   stringUsingNotBlankAndNotNull:String,
 
+  @NotEmpty
+  stringUsingNotEmpty:String,
+
+  @NotEmpty
+  notEmptyStringArray:List[String], // Per PojoArraysWithScala, we use always use Lists in Scala, and never raw arrays.
+
+  @NotEmpty
+  notEmptyMap:Map[String, String],
+
   @Size(min=1, max=20)
   stringUsingSize:String,
 


### PR DESCRIPTION
* `@NotEmpty` annotation will now mark a property as required and:
    * Mark an array property as having a `minItems` of `1`
    * Mark a string property as having a `minLength` of `1`
    * Mark a map property as having a `minProperties` of `1`
* Update JsonSchemaGenerator to respect `@NotEmpty` annotations
* Add string/array/map properties to both Scala class and POJO containing `@NotEmpty` annotations
* Add tests for the new annotation

Closes mbknor/mbknor-jackson-jsonSchema/#56