### PR TITLE
Added support for @DecimalMin, @DecimalMax annotations

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -543,7 +543,7 @@ class JsonSchemaGenerator
 
       node.put("type", "number")
 
-      // Look for @Min, @Max => minimum, maximum
+      // Look for @Min, @Max, @DecimalMin, @DecimalMax => minimum, maximum
       currentProperty.map {
         p =>
           Option(p.getAnnotation(classOf[Min])).map {
@@ -554,6 +554,16 @@ class JsonSchemaGenerator
           Option(p.getAnnotation(classOf[Max])).map {
             max =>
               node.put("maximum", max.value())
+          }
+
+          Option(p.getAnnotation(classOf[DecimalMin])).map {
+            decimalMin =>
+              node.put("minimum", decimalMin.value())
+          }
+
+          Option(p.getAnnotation(classOf[DecimalMax])).map {
+            decimalMax =>
+              node.put("maximum", decimalMax.value())
           }
 
           // Look for @JsonSchemaDefault

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -569,7 +569,7 @@ class JsonSchemaGenerator
           // Look for @JsonSchemaDefault
           Option(p.getAnnotation(classOf[JsonSchemaDefault])).map {
             defaultValue =>
-              node.put("default", defaultValue.value().toLong )
+              node.put("default", defaultValue.value() )
           }
       }
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -558,12 +558,12 @@ class JsonSchemaGenerator
 
           Option(p.getAnnotation(classOf[DecimalMin])).map {
             decimalMin =>
-              node.put("minimum", decimalMin.value())
+              node.put("minimum", decimalMin.value().toDouble)
           }
 
           Option(p.getAnnotation(classOf[DecimalMax])).map {
             decimalMax =>
-              node.put("maximum", decimalMax.value())
+              node.put("maximum", decimalMax.value().toDouble)
           }
 
           // Look for @JsonSchemaDefault


### PR DESCRIPTION
Fix for https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/79
Now `@DecimalMin` and `@DecimalMax` is supported. And seems like `BigDecimal` already processed.

## Update
Added support for for specifying default value for decimal numbers.