### PR TITLE
Use TypeIdResolver from Jackson

### DIFF
--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -18,13 +18,11 @@ import com.kjetland.jackson.jsonSchema.testData._
 import com.kjetland.jackson.jsonSchema.testData.mixin.{MixinChild1, MixinModule, MixinParent}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism1.{Child1, Child2, Parent}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism2.{Child21, Child22, Parent2}
-import com.kjetland.jackson.jsonSchema.testData.polymorphism2.{Child22, Parent2}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism3.{Child31, Child32, Parent3}
-import com.kjetland.jackson.jsonSchema.testData.polymorphism4.{Child41, Child42, Parent4}
+import com.kjetland.jackson.jsonSchema.testData.polymorphism4.{Child41, Child42}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism5.{Child51, Child52, Parent5}
 import com.kjetland.jackson.jsonSchema.testDataScala._
 import com.kjetland.jackson.jsonSchema.testData_issue_24.EntityWrapper
-import io.github.classgraph.ClassGraph
 import org.scalatest.{FunSuite, Matchers}
 
 import scala.collection.JavaConverters._
@@ -489,6 +487,9 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
 
       assertChild1(schema, "/oneOf", "Child51", typeParamName = "clazz", typeName = ".Child51")
       assertChild2(schema, "/oneOf", "Child52", typeParamName = "clazz", typeName = ".Child52")
+
+      val embeddedTypeName = _objectMapper.valueToTree[ObjectNode](new Parent5.Child51InnerClass()).get("clazz").asText()
+      assertChild1(schema, "/oneOf", "Child51InnerClass", typeParamName = "clazz", typeName = embeddedTypeName)
     }
   }
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism5/Parent5.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism5/Parent5.java
@@ -1,5 +1,6 @@
 package com.kjetland.jackson.jsonSchema.testData.polymorphism5;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(
@@ -24,5 +25,41 @@ public abstract class Parent5 {
     @Override
     public int hashCode() {
         return parentString != null ? parentString.hashCode() : 0;
+    }
+
+    public static class Child51InnerClass extends Parent5 {
+
+        public String child1String;
+
+        @JsonProperty("_child1String2")
+        public String child1String2;
+
+        @JsonProperty(value = "_child1String3", required = true)
+        public String child1String3;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Child51)) return false;
+            if (!super.equals(o)) return false;
+
+            Child51 child1 = (Child51) o;
+
+            if (child1String != null ? !child1String.equals(child1.child1String) : child1.child1String != null)
+                return false;
+            if (child1String2 != null ? !child1String2.equals(child1.child1String2) : child1.child1String2 != null)
+                return false;
+            return child1String3 != null ? child1String3.equals(child1.child1String3) : child1.child1String3 == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + (child1String != null ? child1String.hashCode() : 0);
+            result = 31 * result + (child1String2 != null ? child1String2.hashCode() : 0);
+            result = 31 * result + (child1String3 != null ? child1String3.hashCode() : 0);
+            return result;
+        }
     }
 }


### PR DESCRIPTION
in order to stay closer to the original id generation.

This also fixes minimal id generation for inner classes and adds a test case for it.