### PR TITLE
Add support for generic types with varying type arguments

### DIFF
--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/BoringClass.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/BoringClass.java
@@ -1,0 +1,27 @@
+package com.kjetland.jackson.jsonSchema.testData.generic;
+
+import java.util.Objects;
+
+public class BoringClass {
+    public int data;
+
+    public BoringClass(int data) {
+        this.data = data;
+    }
+
+    public BoringClass() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BoringClass that = (BoringClass) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClass.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClass.java
@@ -1,0 +1,28 @@
+package com.kjetland.jackson.jsonSchema.testData.generic;
+
+import java.util.Objects;
+
+public class GenericClass<T> {
+    public T data;
+
+    public GenericClass(T data) {
+        this.data = data;
+    }
+
+    public GenericClass() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GenericClass<?> that = (GenericClass<?>) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+}
+

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClassContainer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClassContainer.java
@@ -1,0 +1,25 @@
+package com.kjetland.jackson.jsonSchema.testData.generic;
+
+import java.util.Objects;
+
+public class GenericClassContainer {
+    public GenericClass<String> child1 = new GenericClass<>("asdf");
+    public GenericClass<BoringClass> child2 = new GenericClass<>(new BoringClass(1337));
+    public GenericClassTwo<String, GenericClass<BoringClass>> child3 =
+            new GenericClassTwo<>("qqq", new GenericClass<>(new BoringClass(1337)));
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GenericClassContainer that = (GenericClassContainer) o;
+        return Objects.equals(child1, that.child1) &&
+                Objects.equals(child2, that.child2) &&
+                Objects.equals(child3, that.child3);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child1, child2, child3);
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClassTwo.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClassTwo.java
@@ -1,0 +1,31 @@
+package com.kjetland.jackson.jsonSchema.testData.generic;
+
+import java.util.Objects;
+
+public class GenericClassTwo<T, U> {
+    public T data1;
+    public U data2;
+
+    public GenericClassTwo(T data1, U data2) {
+        this.data1 = data1;
+        this.data2 = data2;
+    }
+
+    public GenericClassTwo() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GenericClassTwo<?, ?> that = (GenericClassTwo<?, ?>) o;
+        return Objects.equals(data1, that.data1) &&
+                Objects.equals(data2, that.data2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data1, data2);
+    }
+}
+


### PR DESCRIPTION
In order to generate something like the following:
```
{
  "$schema" : "http://json-schema.org/draft-04/schema#",
  "title" : "Generic Class Container",
  "type" : "object",
  "additionalProperties" : false,
  "properties" : {
    "child1" : {
      "$ref" : "#/definitions/GenericClass[String]"
    },
    "child2" : {
      "$ref" : "#/definitions/GenericClass[BoringClass]"
    },
    "child3" : {
      "$ref" : "#/definitions/GenericClassTwo[String,GenericClass[BoringClass]]"
    }
  },
  "definitions" : {
    "GenericClass[String]" : {
      "type" : "object",
      "additionalProperties" : false,
      "properties" : {
        "data" : {
          "type" : "string"
        }
      }
    },
    "GenericClass[BoringClass]" : {
      "type" : "object",
      "additionalProperties" : false,
      "properties" : {
        "data" : {
          "$ref" : "#/definitions/BoringClass"
        }
      }
    },
    "BoringClass" : {
      "type" : "object",
      "additionalProperties" : false,
      "properties" : {
        "data" : {
          "type" : "integer"
        }
      },
      "required" : [ "data" ]
    },
    "GenericClassTwo[String,GenericClass[BoringClass]]" : {
      "type" : "object",
      "additionalProperties" : false,
      "properties" : {
        "data1" : {
          "type" : "string"
        },
        "data2" : {
          "$ref" : "#/definitions/GenericClass[BoringClass]"
        }
      }
    }
  }
}
```

from

```
public class GenericClassContainer {
    public GenericClass<String> child1 = new GenericClass<>("asdf");
    public GenericClass<BoringClass> child2 = new GenericClass<>(new BoringClass(1337));
    public GenericClassTwo<String, GenericClass<BoringClass>> child3 =
            new GenericClassTwo<>("qqq", new GenericClass<>(new BoringClass(1337)));

    @Override
    public boolean equals(Object o) {
        if (this == o) return true;
        if (o == null || getClass() != o.getClass()) return false;
        GenericClassContainer that = (GenericClassContainer) o;
        return Objects.equals(child1, that.child1) &&
                Objects.equals(child2, that.child2) &&
                Objects.equals(child3, that.child3);
    }

    @Override
    public int hashCode() {
        return Objects.hash(child1, child2, child3);
    }
}
```