### PR TITLE
Change Square brackets in URI fragment to round parentheses

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -339,7 +339,7 @@ class JsonSchemaGenerator
       if (_type.hasGenericTypes) {
         val containedTypes = Range(0, _type.containedTypeCount()).map(_type.containedType)
         val typeNames = containedTypes.map(getDefinitionName).mkString(",")
-        s"$baseName[$typeNames]"
+        s"$baseName($typeNames)"
       } else {
         baseName
       }

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -537,10 +537,10 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
       val schema = generateAndValidateSchema(g, classOf[GenericClassContainer], Some(jsonNode))
 
       assert(schema.at("/definitions/BoringClass/properties/data/type").asText() == "integer")
-      assert(schema.at("/definitions/GenericClass[String]/properties/data/type").asText() == "string")
-      assert(schema.at("/definitions/GenericClass[BoringClass]/properties/data/$ref").asText() == "#/definitions/BoringClass")
-      assert(schema.at("/definitions/GenericClassTwo[String,GenericClass[BoringClass]]/properties/data1/type").asText() == "string")
-      assert(schema.at("/definitions/GenericClassTwo[String,GenericClass[BoringClass]]/properties/data2/$ref").asText() == "#/definitions/GenericClass[BoringClass]")
+      assert(schema.at("/definitions/GenericClass(String)/properties/data/type").asText() == "string")
+      assert(schema.at("/definitions/GenericClass(BoringClass)/properties/data/$ref").asText() == "#/definitions/BoringClass")
+      assert(schema.at("/definitions/GenericClassTwo(String,GenericClass(BoringClass))/properties/data1/type").asText() == "string")
+      assert(schema.at("/definitions/GenericClassTwo(String,GenericClass(BoringClass))/properties/data2/$ref").asText() == "#/definitions/GenericClass(BoringClass)")
     }
   }
 


### PR DESCRIPTION
See my [comment on PR #94](https://github.com/mbknor/mbknor-jackson-jsonSchema/pull/94#issuecomment-477793657) - this change to support generic types generates invalid URI fragments, so the schemas generated by this library become invalid.

This change changes the square brackets to round parentheses - these are allowed in URIs. This makes the URIs looks nicer in json-schema files than percent-encoding of the square brackets.