### PR TITLE
Ref #101 Added 'Automatic-Module-Name' to META-INF/MANIFEST.MF to fix JDK9+-issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,9 @@ lazy val commonSettings = Seq(
       Seq("-no-java-comments") //workaround for scala/scala-dev#249
     case _ =>
       Seq()
-  }
+  },
+  packageOptions in (Compile, packageBin) +=
+    Package.ManifestAttributes( "Automatic-Module-Name" -> "mbknor.jackson.jsonschema" )
 )
 
 


### PR DESCRIPTION
When building this fix produces the following MANIFEST.MF-file:
```
Manifest-Version: 1.0
Implementation-Title: mbknor-jackson-jsonSchema
Automatic-Module-Name: mbknor.jackson.jsonschema
Implementation-Version: 1.0.36-SNAPSHOT
Specification-Vendor: mbknor
Specification-Title: mbknor-jackson-jsonSchema
Implementation-Vendor-Id: com.kjetland
Specification-Version: 1.0.36-SNAPSHOT
Implementation-URL: https://github.com/mbknor/mbknor-jackson-jsonSchem
 a
Implementation-Vendor: mbknor
```

And when running `jar --describe-module --file=mbknor-jackson-jsonschema_2.12-1.0.36-SNAPSHOT.jar` it produces the following output:
```
No module descriptor found. Derived automatic module.

mbknor.jackson.jsonschema@1.0.36-SNAPSHOT automatic
requires java.base mandated
contains com.kjetland.jackson.jsonSchema
contains com.kjetland.jackson.jsonSchema.annotations
```

To me it looks like it fixes the issue..  What do you think @jflefebvre06 ?