### PR TITLE
Using jackson @JsonTypeName value for schema definition name if defined

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -404,24 +404,27 @@ class JsonSchemaGenerator
       workInProgressStack = workInProgressStack.tail
     }
 
+    def extractTypeName(_type:JavaType) : String = {
+      // use JsonTypeName annotation if present
+      val annotation = _type.getRawClass.getDeclaredAnnotation(classOf[JsonTypeName])
+      if (annotation != null) {
+        val name = annotation.value();
+        if (name != null && !name.isEmpty) {
+          return name
+        }
+      }
+
+      _type.getRawClass.getSimpleName
+    }
 
     def getDefinitionName (_type:JavaType) : String = {
-      val baseName = if (config.useTypeIdForDefinitionName) _type.getRawClass.getTypeName else _type.getRawClass.getSimpleName
+      val baseName = if (config.useTypeIdForDefinitionName) _type.getRawClass.getTypeName else extractTypeName(_type)
 
       if (_type.hasGenericTypes) {
         val containedTypes = Range(0, _type.containedTypeCount()).map(_type.containedType)
         val typeNames = containedTypes.map(getDefinitionName).mkString(",")
         s"$baseName($typeNames)"
       } else {
-        // use JsonTypeName annotation if present
-        val annotation = _type.getRawClass.getDeclaredAnnotation(classOf[JsonTypeName])
-        if (annotation != null) {
-          val name = annotation.value();
-          if (!name.isEmpty) {
-            return name
-          }
-        }
-
         baseName
       }
     }

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -418,7 +418,7 @@ class JsonSchemaGenerator
         if (annotation != null) {
           val name = annotation.value();
           if (!name.isEmpty) {
-            return name.toString
+            return name
           }
         }
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -955,6 +955,21 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
 
   }
 
+  test("using JavaType with @JsonTypeName") {
+    val config = JsonSchemaConfig.vanillaJsonSchemaDraft4
+    val g = new JsonSchemaGenerator(_objectMapper, debug = true, config)
+
+    val instance = new BoringContainer();
+    instance.child1 = new PojoUsingJsonTypeName();
+    instance.child1.stringWithDefault = "test";
+    val jsonNode = assertToFromJson(g, instance)
+    assertToFromJson(g, instance, classOf[BoringContainer])
+
+    val schema = generateAndValidateSchema(g, classOf[BoringContainer], Some(jsonNode))
+
+    assert(schema.at("/definitions/OtherTypeName/type").asText() == "object");
+  }
+
   test("scala using option with HTML5") {
     val jsonNode = assertToFromJson(jsonSchemaGeneratorScalaHTML5, testData.pojoUsingOptionScala)
     val schema = generateAndValidateSchema(jsonSchemaGeneratorScalaHTML5, testData.pojoUsingOptionScala.getClass, Some(jsonNode))

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -563,6 +563,7 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
 
       assert(schema.at("/definitions/BoringClass/properties/data/type").asText() == "integer")
       assert(schema.at("/definitions/GenericClass(String)/properties/data/type").asText() == "string")
+      assert(schema.at("/definitions/GenericWithJsonTypeName(String)/properties/data/type").asText() == "string")
       assert(schema.at("/definitions/GenericClass(BoringClass)/properties/data/$ref").asText() == "#/definitions/BoringClass")
       assert(schema.at("/definitions/GenericClassTwo(String,GenericClass(BoringClass))/properties/data1/type").asText() == "string")
       assert(schema.at("/definitions/GenericClassTwo(String,GenericClass(BoringClass))/properties/data2/$ref").asText() == "#/definitions/GenericClass(BoringClass)")

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/BoringContainer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/BoringContainer.java
@@ -1,0 +1,27 @@
+package com.kjetland.jackson.jsonSchema.testData;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class BoringContainer {
+
+    @JsonProperty("child1")
+    public PojoUsingJsonTypeName child1;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        BoringContainer that = (BoringContainer) o;
+        return Objects.equals(child1, that.child1);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child1);
+    }
+
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingJsonTypeName.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/PojoUsingJsonTypeName.java
@@ -1,0 +1,34 @@
+package com.kjetland.jackson.jsonSchema.testData;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
+
+import java.util.Objects;
+
+@JsonSchemaDescription("This is our pojo")
+@JsonSchemaTitle("Pojo using format")
+@JsonTypeName("OtherTypeName")
+public class PojoUsingJsonTypeName {
+
+    public String stringWithDefault;
+
+    public PojoUsingJsonTypeName() {
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        PojoUsingJsonTypeName that = (PojoUsingJsonTypeName) o;
+        return Objects.equals(stringWithDefault, that.stringWithDefault);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stringWithDefault);
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClassContainer.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClassContainer.java
@@ -8,6 +8,8 @@ public class GenericClassContainer {
     public GenericClassTwo<String, GenericClass<BoringClass>> child3 =
             new GenericClassTwo<>("qqq", new GenericClass<>(new BoringClass(1337)));
 
+    public GenericClassWithJsonTypeName<String> child4 = new GenericClassWithJsonTypeName<>("testString");
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClassWithJsonTypeName.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/generic/GenericClassWithJsonTypeName.java
@@ -1,0 +1,31 @@
+package com.kjetland.jackson.jsonSchema.testData.generic;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Objects;
+
+@JsonTypeName("GenericWithJsonTypeName")
+public class GenericClassWithJsonTypeName<T> {
+    public T data;
+
+    public GenericClassWithJsonTypeName(T data) {
+        this.data = data;
+    }
+
+    public GenericClassWithJsonTypeName() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GenericClassWithJsonTypeName<?> that = (GenericClassWithJsonTypeName<?>) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+}
+


### PR DESCRIPTION
We use version information in classnames (to support multiple versions in parallel and only add version info in package name was confusing), e.g. "PersonV1" but we want to hide this info in the generated schema. With the Jackson annotation @JsonTypeName you can define a type name different than the class name for the JSON content itself (e.g. "Person"). Added support for the JSON Schema definition for @JsonTypeName in this branch. If @JsonTypeName is defined this will be used instead of class simpleName. In this solution nothing will change for the "useTypeIdForDefinitionName" case/configuration.

What do you think about it? @mbknor