### PR TITLE
generate correct schema if parent class has only a single child

### DIFF
--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -23,6 +23,7 @@ import com.kjetland.jackson.jsonSchema.testData.polymorphism2.{Child21, Child22,
 import com.kjetland.jackson.jsonSchema.testData.polymorphism3.{Child31, Child32, Parent3}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism4.{Child41, Child42}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism5.{Child51, Child52, Parent5}
+import com.kjetland.jackson.jsonSchema.testData.polymorphism6.{Child61, Parent6}
 import com.kjetland.jackson.jsonSchema.testDataScala._
 import com.kjetland.jackson.jsonSchema.testData_issue_24.EntityWrapper
 import javax.validation.groups.Default
@@ -479,6 +480,23 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
     }
 
   }
+
+  test("Generate schema for super class annotated with @JsonTypeInfo - single child class") {
+
+    // Java
+    {
+      val jsonNode = assertToFromJson(jsonSchemaGenerator, testData.child61)
+      assertToFromJson(jsonSchemaGenerator, testData.child61, classOf[Parent6])
+
+      val schema = generateAndValidateSchema(jsonSchemaGenerator, classOf[Parent6], Some(jsonNode))
+
+      val child1 = getNodeViaRefs(schema, schema, "Child61")
+      assertJsonSubTypesInfo(child1, "type", "child61")
+      assert(child1.at("/properties/parentString/type").asText() == "string")
+      assert(child1.at("/properties/child1String/type").asText() == "string")
+    }
+  }
+
 
   test("Generate schema for super class annotated with @JsonTypeInfo - use = JsonTypeInfo.Id.CLASS") {
 
@@ -1769,6 +1787,12 @@ trait TestData {
     c
   }
 
+  val child61 = {
+    val c = new Child61()
+    c.parentString = "pv"
+    c.child1String = "cs"
+    c
+  }
 
   val child2Scala = Child2Scala("pv", 12)
   val child1Scala = Child1Scala("pv", "cs", "cs2", "cs3")

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Child61.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Child61.java
@@ -1,0 +1,25 @@
+package com.kjetland.jackson.jsonSchema.testData.polymorphism6;
+
+public class Child61 extends Parent6 {
+
+    public String child1String;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Child61)) return false;
+        if (!super.equals(o)) return false;
+
+        Child61 child1 = (Child61) o;
+
+        return child1String != null ? child1String.equals(child1.child1String) : child1.child1String == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (child1String != null ? child1String.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Parent6.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Parent6.java
@@ -1,0 +1,31 @@
+package com.kjetland.jackson.jsonSchema.testData.polymorphism6;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = Child61.class, name = "child61") })
+public abstract class Parent6 {
+
+    public String parentString;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Parent6 parent = (Parent6) o;
+
+        return parentString != null ? parentString.equals(parent.parentString) : parent.parentString == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return parentString != null ? parentString.hashCode() : 0;
+    }
+}


### PR DESCRIPTION
Parent classes that only have a single child (e.g. because they are open for extension, but not yet have more children) are generating a wrong schema. The emitted oneOf element has only a single $ref, which is not valid. It needs at least two array elements. This is changed, so that oneOf is only emitted if more than one child is available.

@mbknor Right now we have a workaround using @JsonSchemaInject but it would be cool to see this fixed.