### PR TITLE
Add support for @JsonTypeInfo on interfaces

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -219,7 +219,10 @@ case class SubclassesResolverImpl
   }
 
   override def getSubclasses(clazz: Class[_]): List[Class[_]] = {
-    reflection.getSubclasses(clazz.getName).loadClasses().asScala.toList
+    if (clazz.isInterface)
+      reflection.getClassesImplementing(clazz.getName).loadClasses().asScala.toList
+    else
+      reflection.getSubclasses(clazz.getName).loadClasses().asScala.toList
   }
 }
 

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGeneratorTest.scala
@@ -23,6 +23,7 @@ import com.kjetland.jackson.jsonSchema.testData.polymorphism2.{Child21, Child22,
 import com.kjetland.jackson.jsonSchema.testData.polymorphism3.{Child31, Child32, Parent3}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism4.{Child41, Child42}
 import com.kjetland.jackson.jsonSchema.testData.polymorphism5.{Child51, Child52, Parent5}
+import com.kjetland.jackson.jsonSchema.testData.polymorphism6.{Child61, Parent6}
 import com.kjetland.jackson.jsonSchema.testDataScala._
 import com.kjetland.jackson.jsonSchema.testData_issue_24.EntityWrapper
 import javax.validation.groups.Default
@@ -516,6 +517,23 @@ class JsonSchemaGeneratorTest extends FunSuite with Matchers {
 
       val embeddedTypeName = _objectMapper.valueToTree[ObjectNode](new Parent5.Child51InnerClass()).get("clazz").asText()
       assertChild1(schema, "/oneOf", "Child51InnerClass", typeParamName = "clazz", typeName = embeddedTypeName)
+    }
+  }
+
+  test("Generate schema for interface annotated with @JsonTypeInfo - use = JsonTypeInfo.Id.MINIMAL_CLASS") {
+
+    // Java
+    {
+      val config = JsonSchemaConfig.vanillaJsonSchemaDraft4
+      val g = new JsonSchemaGenerator(_objectMapper, debug = true, config)
+
+      val jsonNode = assertToFromJson(g, testData.child61)
+      assertToFromJson(g, testData.child61, classOf[Parent6])
+
+      val schema = generateAndValidateSchema(g, classOf[Parent6], Some(jsonNode))
+
+      assertChild1(schema, "/oneOf", "Child61", typeParamName = "clazz", typeName = ".Child61")
+      assertChild2(schema, "/oneOf", "Child62", typeParamName = "clazz", typeName = ".Child62")
     }
   }
 
@@ -1768,7 +1786,14 @@ trait TestData {
     c.child2int = 12
     c
   }
-
+  val child61 = {
+    val c = new Child61()
+    c.parentString = "pv"
+    c.child1String = "cs"
+    c.child1String2 = "cs2"
+    c.child1String3 = "cs3"
+    c
+  }
 
   val child2Scala = Child2Scala("pv", 12)
   val child1Scala = Child1Scala("pv", "cs", "cs2", "cs3")

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Child61.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Child61.java
@@ -1,0 +1,36 @@
+package com.kjetland.jackson.jsonSchema.testData.polymorphism6;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class Child61 implements Parent6 {
+
+    public String child1String;
+
+    @JsonProperty("_child1String2")
+    public String child1String2;
+
+    @JsonProperty(value = "_child1String3", required = true)
+    public String child1String3;
+
+    public String parentString;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Child61)) return false;
+
+        Child61 child1 = (Child61) o;
+
+        return Objects.equals(child1String, child1.child1String)
+                && Objects.equals(child1String2, child1.child1String2)
+                && Objects.equals(child1String3, child1.child1String3)
+                && Objects.equals(parentString, child1.parentString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child1String, child1String2, child1String3, parentString);
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Child62.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Child62.java
@@ -1,0 +1,26 @@
+package com.kjetland.jackson.jsonSchema.testData.polymorphism6;
+
+import java.util.Objects;
+
+public class Child62 implements Parent6 {
+
+    public Integer child2int;
+
+    public String parentString;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Child62)) return false;
+
+        Child62 child2 = (Child62) o;
+
+        return Objects.equals(child2int, child2.child2int)
+                && Objects.equals(parentString, child2.parentString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child2int, parentString);
+    }
+}

--- a/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Parent6.java
+++ b/src/test/scala/com/kjetland/jackson/jsonSchema/testData/polymorphism6/Parent6.java
@@ -1,0 +1,11 @@
+package com.kjetland.jackson.jsonSchema.testData.polymorphism6;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.MINIMAL_CLASS,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "clazz")
+public interface Parent6 {
+
+}


### PR DESCRIPTION
fixes: https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/134

Jackson supports `@JsonTypeInfo` on interfaces, not just classes. If `use` is set to anything other than `Id.Type` then currently the generator invokes `ClassGraph` to find the the subtypes of the type. However, `ClassGraph` has different methods for finding implementations of an interface vs subtypes of a class: `getClassesImplementing` vs `getSubclasses` respectively.

This change enhances the generator to call `getClassesImplementing` when the type annotated with `@JsonTypeInfo` is an interface.