### PR TITLE
Adds a callback to user code when resolving a polymorphic type

### DIFF
--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -152,7 +152,7 @@ object JsonSchemaConfig {
 }
 
 trait SubclassesResolver {
-  def resolving(_type: JavaType) {}
+  def resolving(_type: JavaType) = {}
   def getSubclasses(clazz:Class[_]):List[Class[_]]
 }
 

--- a/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -152,7 +152,7 @@ object JsonSchemaConfig {
 }
 
 trait SubclassesResolver {
-  def resolving(_type: JavaType)
+  def resolving(_type: JavaType) {}
   def getSubclasses(clazz:Class[_]):List[Class[_]]
 }
 


### PR DESCRIPTION
fixes: https://github.com/mbknor/mbknor-jackson-jsonSchema/issues/137

Alternative fix: (which I think I prefer) #139 

Adds a callback to `SubclassesResolver` that is invoked when the generator is about to search for subtypes of a type annotated with `@JsonTypeInfo`, passing the type being resolved:

```scala
  def resolving(_type: JavaType)def resolving(_type: JavaType) = {}
```

This allows users to, optionally, execute custom code _before_ ClassGraph attempts to determine the subtypes.

