### PR TITLE
Separate required from nullability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ val slf4jVersion = "1.7.26"
 lazy val deps  = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "javax.validation" % "validation-api" % "2.0.1.Final",
+  "com.google.code.findbugs" % "jsr305" % "3.+" % "compile",
   "org.slf4j" % "slf4j-api" % slf4jVersion,
   "io.github.classgraph" % "classgraph" % "4.8.21",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",

--- a/src/test/java/com/kjetland/jackson/jsonSchema/UseItFromJavaTest.java
+++ b/src/test/java/com/kjetland/jackson/jsonSchema/UseItFromJavaTest.java
@@ -28,6 +28,7 @@ public class UseItFromJavaTest {
         JsonSchemaConfig config = JsonSchemaConfig.create(
                 true,
                 Optional.of("A"),
+                false,
                 true,
                 true,
                 true,


### PR DESCRIPTION
Validators like the Helm validator make a distinction between required and nullable properties. This makes sense.

This commit:

   - Allows primitive properties to be optional (they may have default values, eg when using `@Jacksonized @Builder`)
   - Allows nullable properties to be required (why not?)
   - Looks for `javax.annotation.Nullable` and `org.jetbrains.annotations.Nullable` properties
   - Adds config option to treat all reference properties as nullable
   - If above is true, looks for `javax.annotation.Nonnull` and related `javax.validation.constraints.`